### PR TITLE
fix(installer): Windows PowerShell 5.1 breaks the inline bun eval — rewrite lockfile registry in pure PowerShell

### DIFF
--- a/clients/install.ps1
+++ b/clients/install.ps1
@@ -92,29 +92,26 @@ function PsQuote([string]$s) { "'" + ($s -replace "'", "''") + "'" }
 function RewriteLockRegistry($ClientsRoot) {
   # bun.lock stores absolute package URLs; writing .npmrc alone cannot redirect
   # those entries. Rewrite the installed copy before bun resolves dependencies.
+  #
+  # Pure PowerShell on purpose (issue #8): Windows PowerShell 5.1 does not escape
+  # embedded double quotes when passing arguments to native commands (only pwsh
+  # 7.3+'s Standard argument passing does), so an inline bun eval whose JS
+  # contains double quotes reaches bun with its quoting destroyed and dies with
+  # "Unterminated string literal" on the stock PowerShell every Windows user
+  # runs. A lockfile rewrite is just a regex replace — no native process, no
+  # quoting hazard, and no hidden "bun must already exist here" dependency.
   $lock = Join-Path $ClientsRoot "bun.lock"
   if (-not (Test-Path $lock)) { return }
-  $previousFile = $env:TRPG_LOCK_FILE
-  $previousRegistry = $env:TRPG_LOCK_REGISTRY
   try {
-    $env:TRPG_LOCK_FILE = $lock
-    $env:TRPG_LOCK_REGISTRY = $Registry
-    bun -e '
-      const path = process.env.TRPG_LOCK_FILE;
-      const registry = (process.env.TRPG_LOCK_REGISTRY || "").replace(/\/+$/, "");
-      if (!path || !registry) process.exit(2);
-      let contents = await Bun.file(path).text();
-      contents = contents.replace(
-        /https:\/\/registry\.(?:npmjs\.org|npmmirror\.com)(?=\/)/g,
-        () => registry,
-      );
-      await Bun.write(path, contents);
-    '
-    if ($LASTEXITCODE -ne 0) { throw "could not apply TRPG_REGISTRY to the client lockfile." }
+    $contents = [IO.File]::ReadAllText($lock)
+    # `$Registry` is already validated + TrimEnd("/")-ed at startup. Escape `$`
+    # so the replacement string cannot be misread as a capture reference.
+    $safeTarget = $Registry -replace '\$', '$$$$'
+    $rewritten = $contents -replace 'https://registry\.(?:npmjs\.org|npmmirror\.com)(?=/)', $safeTarget
+    if ($rewritten -ne $contents) { [IO.File]::WriteAllText($lock, $rewritten) }
   }
-  finally {
-    $env:TRPG_LOCK_FILE = $previousFile
-    $env:TRPG_LOCK_REGISTRY = $previousRegistry
+  catch {
+    throw "could not apply TRPG_REGISTRY to the client lockfile. ($_)"
   }
 }
 

--- a/tests/test_client_installers.py
+++ b/tests/test_client_installers.py
@@ -473,7 +473,14 @@ def test_both_installers_rewrite_absolute_lock_urls_before_bun_install():
 
     for text in (bash, powershell):
         assert "registry\\.(?:npmjs\\.org|npmmirror\\.com)" in text
-        assert "() => registry" in text
+
+    # The bash installer rewrites via an inline `bun -e` script (single-quoted args are safe
+    # there); the PowerShell installer must NOT — Windows PowerShell 5.1 mangles embedded
+    # double quotes in native-command arguments (issue #8), so it rewrites in pure PowerShell.
+    assert "() => registry" in bash
+    assert "bun -e" not in powershell
+    assert "[IO.File]::ReadAllText($lock)" in powershell
+    assert "[IO.File]::WriteAllText($lock, $rewritten)" in powershell
 
     assert bash.index('rewrite_lock_registry "$STAGED_CLIENTS"') < bash.index("bun install --silent")
     assert powershell.rindex("RewriteLockRegistry $StagedClients") < powershell.index("bun install --silent")


### PR DESCRIPTION
Fixes #8

## What broke

The documented Windows install path (`irm .../install.ps1 | iex`) runs under **Windows PowerShell 5.1**, which does not escape embedded double quotes when passing arguments to native commands (only pwsh 7.3+'s `PSNativeCommandArgumentPassing=Standard` does). `install.ps1`'s registry rewrite invoked `bun -e '<multi-line JS>'` whose script contains `|| ""` — the quoting was destroyed in transit and bun died with:

```
error: Unterminated string literal
    at [eval]:3:59
```

…line 3 column 59 being exactly that `""`. The script then threw `could not apply TRPG_REGISTRY to the client lockfile.` (line 113), matching the report in #8 byte for byte. Dev machines and CI run pwsh 7.3+, which is why this never reproduced locally.

## The fix

The lockfile rewrite is a plain regex replace, so do it in pure PowerShell (`[IO.File]::ReadAllText` + `-replace` + `WriteAllText`): no native-process argument passing at all, works identically on 5.1 and 7.x, and drops the hidden assumption that bun already exists at that point. `$` in the replacement target is escaped so a registry URL can never be misread as a capture reference. `install.sh` is untouched (bash single-quoted args pass through intact).

Installer test updated: it now asserts the PowerShell installer contains **no** `bun -e` invocation and uses the pure-PS read/replace/write path, while the bash installer keeps its (safe) inline eval.

## After merge

The fixed `install.ps1` needs to replace the asset on the v1.0.0 release (`gh release upload --clobber`) so `releases/latest/download/install.ps1` serves the working version.