### PR TITLE
test(ci): review-lane probe — verify claude-review posts (close unmerged)

### DIFF
--- a/.github/REVIEW_LANE_PROBE.md
+++ b/.github/REVIEW_LANE_PROBE.md
@@ -1,0 +1,2 @@
+Probe PR to verify the claude-review lane posts after the Task-tool allowlist fix (cd5e6fa).
+Safe to close unmerged; the branch is deleted afterwards.


### PR DESCRIPTION
One-file probe opened right after cd5e6fa to confirm the claude-review lane actually posts a comment now that the Task tool is allowlisted. Will be closed unmerged once the review lands (or fails to).