### PR TITLE
fix(admin): refuse to demote or delete a room's last keeper key

### DIFF
--- a/clients/tui/src/screens/KeeperKeys.tsx
+++ b/clients/tui/src/screens/KeeperKeys.tsx
@@ -210,6 +210,13 @@ export function KeeperKeys({ client, theme, themeName, welcome, stateFrame, onBa
     setRoleIndex(selected.role === "keeper" ? 1 : 0)
   }
 
+  // The edit form doubles as the mint form; keep it synced to the SELECTED key whenever the
+  // selection or the key list changes, so a save can never write a stale role/name onto a
+  // different key (this has demoted the bootstrap keeper key in the wild).
+  useEffect(() => {
+    loadSelected()
+  }, [selectedKey, keys])
+
   const updateSelected = () => {
     setConfirming(null)
     if (!selected || selectedChatBinding) return

--- a/locales/en/tui.json
+++ b/locales/en/tui.json
@@ -32,6 +32,7 @@
   "tui.admin.error.op_failed": "Room backup, import, or delete failed. Check the path and server file permissions.",
   "tui.admin.error.set_failed": "Could not finish configuring the LLM provider. Check its SDK, credentials, and storage, then retry.",
   "tui.admin.error.not_configured": "Server self-update is not enabled. Set TRPG_TUI__UPDATE_COMMAND on the server to allow it.",
+  "tui.admin.error.last_keeper": "This is the room's last keeper key and cannot be demoted or deleted — mint a second keeper key first if you need to change it.",
   "tui.serve.listening": "Serving the networked TUI at ws://{host}:{port}/ (keys: {path})",
   "tui.serve.bootstrap.banner": "★ First run: no keys yet, so minted a keeper key for room '{room}'.",
   "tui.serve.bootstrap.key": "  Keeper key: {key}",

--- a/locales/zh/tui.json
+++ b/locales/zh/tui.json
@@ -32,6 +32,7 @@
   "tui.admin.error.op_failed": "房间备份、导入或删除操作失败，请检查路径和服务端文件权限。",
   "tui.admin.error.set_failed": "未能完成 LLM 提供方配置。请检查 SDK、凭据和存储后重试。",
   "tui.admin.error.not_configured": "服务端自更新未启用。请在服务端设置 TRPG_TUI__UPDATE_COMMAND 以允许更新。",
+  "tui.admin.error.last_keeper": "这是房间最后一个守秘人（keeper）密钥，不能降级或删除——如需变更，请先铸造第二个守秘人密钥。",
   "tui.serve.listening": "已在 ws://{host}:{port}/ 提供联网 TUI 服务（密钥文件：{path}）",
   "tui.serve.bootstrap.banner": "★ 首次启动：密钥库为空，已为房间「{room}」自动发放一个守秘人 key。",
   "tui.serve.bootstrap.key": "  守秘人 key：{key}",

--- a/net/admin.py
+++ b/net/admin.py
@@ -762,7 +762,9 @@ def _last_keeper_error(i18n: I18n) -> dict[str, Any]:
 
 
 def _keeper_count(keystore: Keystore, room: str) -> int:
-    return sum(1 for e in keystore.entries(purpose=None) if e.room == room and e.role == "keeper")
+    # Join keys only (the entries() default): a pending keeper chat_bind token cannot
+    # authenticate a connection, so it must not count toward "the room still has a keeper".
+    return sum(1 for e in keystore.entries() if e.room == room and e.role == "keeper")
 
 
 def _update_key(keystore: Keystore, caller_room: str, frame: dict[str, Any], i18n: I18n) -> dict[str, Any]:

--- a/net/admin.py
+++ b/net/admin.py
@@ -750,6 +750,21 @@ def _mint_key(
     return _keys_frame(keystore, caller_room, minted=minted)
 
 
+def _last_keeper_error(i18n: I18n) -> dict[str, Any]:
+    """Anti-lockout: a room's last keeper key can never be demoted or deleted.
+
+    The TUI's KeeperKeys form doubles as mint + edit surface; a stale role in the
+    form has already demoted the bootstrap keeper key in the wild (the room then
+    permanently loses every keeper surface). Refusing the transition server-side
+    makes lockout impossible even if a client misbehaves.
+    """
+    return _error("last_keeper", i18n)
+
+
+def _keeper_count(keystore: Keystore, room: str) -> int:
+    return sum(1 for e in keystore.entries(purpose=None) if e.room == room and e.role == "keeper")
+
+
 def _update_key(keystore: Keystore, caller_room: str, frame: dict[str, Any], i18n: I18n) -> dict[str, Any]:
     key_id = str(frame.get("id") or "").strip()
     updates: dict[str, str] = {}
@@ -780,6 +795,11 @@ def _update_key(keystore: Keystore, caller_room: str, frame: dict[str, Any], i18
         entry = keystore.get(key, purpose=None)
         if entry is None or entry.room != caller_room:
             return _error("forbidden", i18n)
+        # Never demote the room's last keeper key: the keeper surface is the only
+        # way to mint new keeper keys, so losing it is a permanent lockout.
+        if entry.role == "keeper" and updates.get("role", "keeper") != "keeper":
+            if _keeper_count(keystore, caller_room) <= 1:
+                return _last_keeper_error(i18n)
         keystore.update(key, **updates)
     return _keys_frame(keystore, caller_room)
 
@@ -793,6 +813,10 @@ def _delete_key(keystore: Keystore, caller_room: str, frame: dict[str, Any], i18
         entry = keystore.get(key, purpose=None)
         if entry is None or entry.room != caller_room:
             return _error("forbidden", i18n)
+        # Same anti-lockout rule as update: deleting the last keeper key would
+        # strand the room without any way to recover keeper access.
+        if entry.role == "keeper" and _keeper_count(keystore, caller_room) <= 1:
+            return _last_keeper_error(i18n)
         keystore.remove(key)
     return _keys_frame(keystore, caller_room)
 

--- a/tests/net/test_admin.py
+++ b/tests/net/test_admin.py
@@ -337,6 +337,60 @@ async def test_keeper_can_get_and_set_config_list_and_mint_keys():
         await server.close()
 
 
+async def test_last_keeper_key_cannot_be_demoted_or_deleted():
+    """Anti-lockout: the room's only keeper key can never lose the keeper role.
+
+    Regression for the TUI form bug that demoted the bootstrap keeper key to
+    player (name/role form state is shared between mint and edit; a stale role
+    was written back onto the selected key), after which the room permanently
+    loses every keeper surface and no new keeper key can be minted.
+    """
+    services = _services()
+    keystore = Keystore()
+    keeper_key = keystore.add(room="arkham", name="Keeper", role="keeper")
+    server = TuiServer(services, keystore, port=0)
+    url = await _start(server)
+    try:
+        ws, *_ = await _connect_and_join(url, keeper_key, "Keeper")
+
+        listed = await _send(ws, {"type": "admin_list_keys"})
+        keeper_id = next(entry["id"] for entry in listed["keys"] if entry["role"] == "keeper")
+
+        # Demoting the last keeper is refused, and nothing is mutated.
+        demote = await _send(ws, {"type": "admin_update_key", "id": keeper_id, "role": "player"})
+        assert demote["type"] == "admin_error"
+        assert demote["code"] == "last_keeper"
+        assert keystore.get(keeper_key).role == "keeper"
+
+        # Deleting the last keeper is refused too.
+        delete = await _send(ws, {"type": "admin_delete_key", "id": keeper_id})
+        assert delete["type"] == "admin_error"
+        assert delete["code"] == "last_keeper"
+        assert keystore.get(keeper_key) is not None
+
+        # With a second keeper key in the room, the FIRST (non-caller) may be demoted.
+        minted = await _send(
+            ws, {"type": "admin_mint_key", "room": "arkham", "name": "Co-Keeper", "role": "keeper"}
+        )
+        second_id = next(entry["id"] for entry in minted["keys"] if entry["name"] == "Co-Keeper")
+        demote = await _send(ws, {"type": "admin_update_key", "id": second_id, "role": "player"})
+        assert demote["type"] == "admin_keys"
+        changed = next(entry for entry in demote["keys"] if entry["id"] == second_id)
+        assert changed["role"] == "player"
+
+        # The caller's key is now the room's last keeper — protected again.
+        delete = await _send(ws, {"type": "admin_delete_key", "id": keeper_id})
+        assert delete["type"] == "admin_error"
+        assert delete["code"] == "last_keeper"
+        demote = await _send(ws, {"type": "admin_update_key", "id": keeper_id, "role": "player"})
+        assert demote["type"] == "admin_error"
+        assert demote["code"] == "last_keeper"
+
+        await ws.close()
+    finally:
+        await server.close()
+
+
 async def test_key_mutation_rechecks_room_after_external_move(tmp_path):
     services = _services(str(tmp_path))
     key_path = tmp_path / "keys.toml"

--- a/tests/net/test_admin.py
+++ b/tests/net/test_admin.py
@@ -368,6 +368,17 @@ async def test_last_keeper_key_cannot_be_demoted_or_deleted():
         assert delete["code"] == "last_keeper"
         assert keystore.get(keeper_key) is not None
 
+        # A pending keeper chat_bind token must NOT inflate the keeper count: it
+        # cannot authenticate a connection, so the join key is still the room's only
+        # keeper access and stays protected while the token is outstanding.
+        minted_bind = await _send(
+            ws, {"type": "admin_mint_key", "room": "arkham", "name": "bind", "purpose": "chat_bind"}
+        )
+        assert minted_bind["type"] == "admin_keys"
+        demote = await _send(ws, {"type": "admin_update_key", "id": keeper_id, "role": "player"})
+        assert demote["type"] == "admin_error"
+        assert demote["code"] == "last_keeper"
+
         # With a second keeper key in the room, the FIRST (non-caller) may be demoted.
         minted = await _send(
             ws, {"type": "admin_mint_key", "room": "arkham", "name": "Co-Keeper", "role": "keeper"}


### PR DESCRIPTION
## Summary

A bug found while playing a local session: the KeeperKeys form doubles as both the **mint** and the **edit-selected-key** surface, sharing one set of form state (name + role). A stale role in that shared state can be written back onto the selected key: in the wild this demoted the bootstrap keeper key to `player`, after which every reconnect silently lost all keeper surfaces (menu rows, admin frames) with no way to recover — the room is permanently locked out.

## Changes

- **Server (`net/admin.py`)**: `admin_update_key` / `admin_delete_key` now refuse to demote or delete a room's **last** keeper key (`last_keeper` error, localized en/zh). Defense in depth — even a misbehaving client can no longer lock a room out.
- **Client (`KeeperKeys.tsx`)**: the edit form now auto-syncs to the selected key whenever the selection or the key list changes, so a save can never write a stale role/name onto a different key.
- **Tests**: `tests/net/test_admin.py::test_last_keeper_key_cannot_be_demoted_or_deleted` covers demote/delete refusal, and the allowed path once a second keeper key exists.

## Verification

- `ruff check net/ tests/` — clean
- `python scripts/i18n_lint.py` — clean
- `pytest tests/net/test_admin.py tests/net/test_keystore.py` — pass (full-suite delta vs baseline: zero new failures)
- `bun test` (tui) — 251 pass / 7 fail, identical to baseline (pre-existing harness failures)
