### PR TITLE
fix(admin): localize the KP skills list and fix the list layout

### DIFF
--- a/clients/protocol/src/client.ts
+++ b/clients/protocol/src/client.ts
@@ -410,12 +410,12 @@ export class WsClient {
 
   // ---- v1.1 additive: Layer B.4a plugin management (KP skills / rule systems / forge) ----
 
-  adminListSkills(): void {
-    this.send({ type: FrameType.AdminListSkills })
+  adminListSkills(locale?: string): void {
+    this.send({ type: FrameType.AdminListSkills, ...(locale ? { locale } : {}) })
   }
 
-  adminEnableSkill(id: string, on: boolean): void {
-    const frame: AdminEnableSkillFrame = { type: FrameType.AdminEnableSkill, id, on }
+  adminEnableSkill(id: string, on: boolean, locale?: string): void {
+    const frame: AdminEnableSkillFrame = { type: FrameType.AdminEnableSkill, id, on, ...(locale ? { locale } : {}) }
     this.send(frame)
   }
 

--- a/clients/protocol/src/types.ts
+++ b/clients/protocol/src/types.ts
@@ -825,6 +825,11 @@ export interface AdminErrorFrame {
 
 export interface AdminListSkillsFrame {
   type: typeof FrameType.AdminListSkills
+  // Optional UI-locale hint ("en" | "zh"): the server localizes skill display
+  // metadata (`name-zh`/`description-zh` frontmatter) to it when present;
+  // absent means the server's own locale applies. Additive — older servers
+  // ignore it and reply with the server-locale list.
+  locale?: string
 }
 
 export interface AdminSkillInfo {
@@ -845,6 +850,9 @@ export interface AdminEnableSkillFrame {
   type: typeof FrameType.AdminEnableSkill
   id: string
   on: boolean
+  // Same optional locale hint as `AdminListSkillsFrame` — the post-toggle
+  // refresh is localized to the requesting client's UI language.
+  locale?: string
 }
 
 export interface AdminListRulesFrame {

--- a/clients/tui/src/client.ts
+++ b/clients/tui/src/client.ts
@@ -58,8 +58,8 @@ export interface AppClient {
   adminResetRoom(room: string, scope?: AdminResetScope): void
   adminUpdateServer(): void
   // v1.1 additive: Layer B.4a plugin management (KP skills / rule systems / self-extension forge).
-  adminListSkills(): void
-  adminEnableSkill(id: string, on: boolean): void
+  adminListSkills(locale?: string): void
+  adminEnableSkill(id: string, on: boolean, locale?: string): void
   adminListRules(): void
   adminGenerate(kind: AdminForgeKind, description: string): void
 }
@@ -164,11 +164,11 @@ class TransportClient implements AppClient {
   adminUpdateServer(): void {
     this.inner?.adminUpdateServer()
   }
-  adminListSkills(): void {
-    this.inner?.adminListSkills()
+  adminListSkills(locale?: string): void {
+    this.inner?.adminListSkills(locale)
   }
-  adminEnableSkill(id: string, on: boolean): void {
-    this.inner?.adminEnableSkill(id, on)
+  adminEnableSkill(id: string, on: boolean, locale?: string): void {
+    this.inner?.adminEnableSkill(id, on, locale)
   }
   adminListRules(): void {
     this.inner?.adminListRules()

--- a/clients/tui/src/irohClient.ts
+++ b/clients/tui/src/irohClient.ts
@@ -448,12 +448,12 @@ export class IrohClient implements AppClient {
   }
 
   // ---- v1.1 additive: Layer B.4a plugin management, identical wire to WsClient ------
-  adminListSkills(): void {
-    this.sendFrame({ type: FrameType.AdminListSkills })
+  adminListSkills(locale?: string): void {
+    this.sendFrame({ type: FrameType.AdminListSkills, ...(locale ? { locale } : {}) })
   }
 
-  adminEnableSkill(id: string, on: boolean): void {
-    const frame: AdminEnableSkillFrame = { type: FrameType.AdminEnableSkill, id, on }
+  adminEnableSkill(id: string, on: boolean, locale?: string): void {
+    const frame: AdminEnableSkillFrame = { type: FrameType.AdminEnableSkill, id, on, ...(locale ? { locale } : {}) }
     this.sendFrame(frame)
   }
 

--- a/clients/tui/src/screens/KeeperSkills.tsx
+++ b/clients/tui/src/screens/KeeperSkills.tsx
@@ -166,9 +166,10 @@ export function KeeperSkills({ client, theme, themeName, welcome, stateFrame, on
             {skills.length ? (
               skills.map((entry: AdminSkillInfo, index: number) => (
                 <box key={entry.id} onMouseDown={() => toggle(entry)}>
-                  <text fg={index === selectedIndex ? theme.accent : theme.fg}>
+                  <text fg={index === selectedIndex ? theme.accent : theme.fg} wrapMode="none" truncate>
                     {index === selectedIndex ? CURSOR : " "} {stripControlChars(entry.name)} ·{" "}
-                    {stripControlChars(entry.description)} · {stripControlChars(entry.content_rating)} ·{" "}
+                    {stripControlChars(entry.description)}
+                    {entry.content_rating ? ` · ${stripControlChars(entry.content_rating)}` : ""} ·{" "}
                     <span fg={entry.enabled ? theme.success : theme.dim}>
                       {entry.enabled ? tt(locale, "skills.on") : tt(locale, "skills.off")}
                     </span>

--- a/clients/tui/src/screens/KeeperSkills.tsx
+++ b/clients/tui/src/screens/KeeperSkills.tsx
@@ -87,12 +87,12 @@ export function KeeperSkills({ client, theme, themeName, welcome, stateFrame, on
         setGenerating(false)
       }
     })
-    client.adminListSkills()
+    client.adminListSkills(locale)
     return off
   }, [client, locale])
 
   const toggle = (entry: AdminSkillInfo) => {
-    client.adminEnableSkill(entry.id, !entry.enabled)
+    client.adminEnableSkill(entry.id, !entry.enabled, locale)
   }
 
   const generate = () => {

--- a/core/skills.py
+++ b/core/skills.py
@@ -58,6 +58,10 @@ class Skill:
     id: str
     name: str
     description: str
+    # Optional localized display metadata (frontmatter `name-zh` / `description-zh`);
+    # empty means the English name/description are used for that locale too.
+    name_zh: str = ""
+    description_zh: str = ""
     allowed_tools: list[str] = field(default_factory=list)
     scope: str = "room"
     systems: list[str] = field(default_factory=list)
@@ -93,8 +97,10 @@ def _build_skill(skill_id: str, frontmatter: Mapping[str, Any], body: str) -> Sk
         metadata = {}
     return Skill(
         id=skill_id,
-        name=str(frontmatter.get("name") or skill_id),
-        description=str(frontmatter.get("description") or ""),
+        name=str(frontmatter.get("name") or skill_id).strip(),
+        description=str(frontmatter.get("description") or "").strip(),
+        name_zh=str(frontmatter.get("name-zh") or "").strip(),
+        description_zh=str(frontmatter.get("description-zh") or "").strip(),
         allowed_tools=[str(item) for item in (frontmatter.get("allowed-tools") or [])],
         scope=str(metadata.get("scope") or "room"),
         systems=[str(item) for item in (metadata.get("systems") or [])],

--- a/net/admin.py
+++ b/net/admin.py
@@ -290,7 +290,7 @@ async def _dispatch_admin_frame(
     if kind == "admin_update_server":
         return await _update_server(services, i18n)
     if kind == "admin_list_skills":
-        return await _skills_frame(services, caller_room)
+        return await _skills_frame(services, caller_room, i18n)
     if kind == "admin_enable_skill":
         return await _enable_skill(services, caller_room, frame, i18n)
     if kind == "admin_list_rules":
@@ -962,16 +962,24 @@ def _room_op_frame(action: str, result: dict[str, Any]) -> dict[str, Any]:
 # -- KP skills (Layer B.1/B.2) ----------------------------------------------
 
 
-async def _skills_frame(services: Services, caller_room: str) -> dict[str, Any]:
+async def _skills_frame(services: Services, caller_room: str, i18n: I18n) -> dict[str, Any]:
     """Answer `admin_list_skills`/a fresh post-`admin_enable_skill` reply: every discoverable
-    skill (`core.skills.available_skills`), each marked `enabled` per the CALLER'S room."""
+    skill (`core.skills.available_skills`), each marked `enabled` per the CALLER'S room.
+
+    `name`/`description` follow the caller's locale when a skill ships `name-zh` /
+    `description-zh` frontmatter (falling back to the English fields), so the list is
+    readable in Chinese without duplicating the skill registry per client.
+    """
     chat_key = chat_key_for_room(caller_room)
     enabled_ids = set(await get_enabled_skills(services.store, chat_key))
+    use_zh = i18n.locale == "zh"
     skills = [
         {
             "id": skill.id,
-            "name": skill.name,
-            "description": skill.description,
+            "name": (skill.name_zh if use_zh and skill.name_zh else skill.name),
+            "description": (
+                skill.description_zh if use_zh and skill.description_zh else skill.description
+            ),
             "content_rating": skill.content_rating,
             "enabled": skill.id in enabled_ids,
         }
@@ -990,7 +998,7 @@ async def _enable_skill(
 
     chat_key = chat_key_for_room(caller_room)
     await toggle_enabled_skill(services.store, chat_key, skill_id, on=bool(frame.get("on")))
-    return await _skills_frame(services, caller_room)
+    return await _skills_frame(services, caller_room, i18n)
 
 
 # -- rule systems (Layer A) ---------------------------------------------------

--- a/net/admin.py
+++ b/net/admin.py
@@ -290,7 +290,7 @@ async def _dispatch_admin_frame(
     if kind == "admin_update_server":
         return await _update_server(services, i18n)
     if kind == "admin_list_skills":
-        return await _skills_frame(services, caller_room, i18n)
+        return await _skills_frame(services, caller_room, i18n, frame)
     if kind == "admin_enable_skill":
         return await _enable_skill(services, caller_room, frame, i18n)
     if kind == "admin_list_rules":
@@ -962,17 +962,20 @@ def _room_op_frame(action: str, result: dict[str, Any]) -> dict[str, Any]:
 # -- KP skills (Layer B.1/B.2) ----------------------------------------------
 
 
-async def _skills_frame(services: Services, caller_room: str, i18n: I18n) -> dict[str, Any]:
+async def _skills_frame(services: Services, caller_room: str, i18n: I18n, frame: dict[str, Any] | None = None) -> dict[str, Any]:
     """Answer `admin_list_skills`/a fresh post-`admin_enable_skill` reply: every discoverable
     skill (`core.skills.available_skills`), each marked `enabled` per the CALLER'S room.
 
     `name`/`description` follow the caller's locale when a skill ships `name-zh` /
-    `description-zh` frontmatter (falling back to the English fields), so the list is
-    readable in Chinese without duplicating the skill registry per client.
+    `description-zh` frontmatter (falling back to the English fields). The locale comes from
+    the request frame when present — a client can pin its own UI language independently of the
+    server's — otherwise the server locale applies.
     """
+    requested = str((frame or {}).get("locale") or "").strip()
+    locale = requested or i18n.locale
     chat_key = chat_key_for_room(caller_room)
     enabled_ids = set(await get_enabled_skills(services.store, chat_key))
-    use_zh = i18n.locale == "zh"
+    use_zh = locale == "zh"
     skills = [
         {
             "id": skill.id,
@@ -998,7 +1001,7 @@ async def _enable_skill(
 
     chat_key = chat_key_for_room(caller_room)
     await toggle_enabled_skill(services.store, chat_key, skill_id, on=bool(frame.get("on")))
-    return await _skills_frame(services, caller_room, i18n)
+    return await _skills_frame(services, caller_room, i18n, frame)
 
 
 # -- rule systems (Layer A) ---------------------------------------------------

--- a/skills/image-gen/SKILL.md
+++ b/skills/image-gen/SKILL.md
@@ -4,6 +4,9 @@ description: >
   Enable to let the Keeper generate occasional player-visible scene, portrait, or item handouts
   through the configured external image provider.
 allowed-tools: [generate_image]
+name-zh: 图像生成
+description-zh: >
+  开启后，Keeper 可通过已配置的外部图像服务，偶尔生成玩家可见的场景、肖像或物品插图。
 metadata:
   scope: room
   content-rating: ""

--- a/skills/mature-mode/SKILL.md
+++ b/skills/mature-mode/SKILL.md
@@ -5,6 +5,9 @@ description: >
   explicitly opted in. Lifts the Keeper's self-censorship for explicit
   romance/intimacy scenes and the room's output word-filter while it is on.
 allowed-tools: []
+name-zh: 成熟模式
+description-zh: >
+  为仅限邀请的私密成人/恋爱战役开启。开启期间解除 Keeper 对露骨浪漫/亲密场景的自我审查，并放宽房间输出的词汇过滤。
 metadata:
   scope: room
   content-rating: explicit

--- a/skills/module-forge/SKILL.md
+++ b/skills/module-forge/SKILL.md
@@ -6,6 +6,9 @@ description: >
   knowledge pool. Turn this on only when you want the Keeper itself to generate and install a new
   module at your request.
 allowed-tools: [generate_module]
+name-zh: 模组锻造
+description-zh: >
+  开启后，Keeper 可根据自然语言描述（或守秘人提供的设定前提）创作一份全新的模组/剧本文档，并直接安装到本房间的模组知识库中。
 metadata:
   scope: room
   content-rating: ""

--- a/skills/romance-relationships/SKILL.md
+++ b/skills/romance-relationships/SKILL.md
@@ -5,6 +5,9 @@ description: >
   tension, resolves seduction and reading feelings as social checks, and
   prompts consent beats before a scene turns intimate.
 allowed-tools: [adjust_relationship, set_relationship, get_relationships]
+name-zh: 恋爱与关系
+description-zh: >
+  为以浪漫/亲密为核心的战役开启：追踪吸引与张力，将诱惑与读心作为社交检定来判定，并在场景转向亲密前提示同意确认。
 metadata:
   scope: room
   systems: [coc7]

--- a/skills/rule-forge/SKILL.md
+++ b/skills/rule-forge/SKILL.md
@@ -5,6 +5,9 @@ description: >
   from a natural-language description of its sheet and checks. Turn this on only when you want the
   Keeper itself to generate and install a new rule system at your request.
 allowed-tools: [generate_rulepack]
+name-zh: 规则锻造
+description-zh: >
+  开启后，Keeper 可根据自然语言描述的属性表与检定方式，创作全新的 TTRPG 规则系统（rulepacks/<id>.yaml 数据包）。
 metadata:
   scope: room
   content-rating: ""

--- a/skills/skill-forge/SKILL.md
+++ b/skills/skill-forge/SKILL.md
@@ -5,6 +5,9 @@ description: >
   desired play-style -- the "skill that creates skills." Turn this on only when you want the
   Keeper itself to generate and install new skills at your request.
 allowed-tools: [generate_skill]
+name-zh: 技能锻造
+description-zh: >
+  开启后，Keeper 可根据自然语言描述的目标玩法风格，创作全新的 KP 技能——即“创造技能的技能”。
 metadata:
   scope: room
   content-rating: ""

--- a/skills/svg-mapmaker/SKILL.md
+++ b/skills/svg-mapmaker/SKILL.md
@@ -4,6 +4,9 @@ description: >
   Enable to let the Keeper draw simple player-visible SVG handout maps: location maps,
   room hierarchy diagrams, clue-route sketches, and relationship/area structures with labels.
 allowed-tools: [draw_svg_map]
+name-zh: SVG 地图制作
+description-zh: >
+  开启后，Keeper 可绘制简单的玩家可见 SVG 地图：地点地图、房间层级图、线索路线草图，以及带标签的关系/区域结构图。
 metadata:
   scope: room
   content-rating: ""

--- a/tests/core/test_skills.py
+++ b/tests/core/test_skills.py
@@ -68,6 +68,20 @@ metadata:
 This is the markdown body folded into the KP prompt.
 """
 
+LOCALIZED_SKILL = """---
+name: Localized Skill
+description: English description.
+name-zh: 本地化技能
+description-zh: >
+  中文描述。
+metadata:
+  scope: room
+  content-rating: mature
+---
+
+# Localized Skill Body
+"""
+
 MALFORMED_NO_FENCE = """name: Malformed
 description: missing the frontmatter fences entirely.
 
@@ -97,6 +111,38 @@ def test_discovers_and_parses_a_fixture_skill_frontmatter_and_body(tmp_path: Pat
     finally:
         skills_module._SKILL_DIR = original_dir
         skills_module._discover_registry.cache_clear()
+
+
+def test_localized_frontmatter_fields_are_parsed(tmp_path: Path) -> None:
+    """A SKILL.md may carry optional `name-zh` / `description-zh` frontmatter so the
+    admin skills list can follow the caller's locale; absent fields stay empty and
+    callers fall back to the English name/description."""
+    _write_skill(tmp_path, "localized-skill", LOCALIZED_SKILL)
+
+    original_dir = skills_module._SKILL_DIR
+    skills_module._SKILL_DIR = tmp_path
+    skills_module._discover_registry.cache_clear()
+    try:
+        skill = load_skill("localized-skill")
+        assert skill is not None
+        assert skill.name == "Localized Skill"
+        assert skill.description == "English description."
+        assert skill.name_zh == "本地化技能"
+        assert skill.description_zh == "中文描述。"
+        # The localized block must not swallow the metadata children that follow it.
+        assert skill.content_rating == "mature"
+        assert skill.scope == "room"
+    finally:
+        skills_module._SKILL_DIR = original_dir
+        skills_module._discover_registry.cache_clear()
+
+
+def test_real_built_in_skills_ship_chinese_display_metadata() -> None:
+    """Every built-in skill carries `name-zh`/`description-zh` so a Chinese-locale
+    client never sees a bare English list."""
+    for skill in available_skills():
+        assert skill.name_zh, f"built-in skill {skill.id} is missing name-zh"
+        assert skill.description_zh, f"built-in skill {skill.id} is missing description-zh"
 
 
 def test_malformed_skill_is_skipped_but_good_skill_still_discovered(tmp_path: Path) -> None:

--- a/tests/net/test_admin.py
+++ b/tests/net/test_admin.py
@@ -139,6 +139,28 @@ def _update_services(command: str):
     return build_services(settings, llm=FakeLLM(script=[]), embeddings=FakeEmbeddings(64))
 
 
+async def test_admin_skills_list_follows_the_caller_locale():
+    """`admin_list_skills` returns the skill's `name-zh`/`description-zh` for a
+    Chinese-locale caller and the English fields otherwise, so the KeeperSkills
+    screen is readable in either language without client-side mappings."""
+    services = _services()
+    admin = AdminService(services, Keystore())
+
+    zh = await admin.dispatch("keeper", "arkham", {"type": "admin_list_skills"}, get_i18n("zh"))
+    assert zh["type"] == "admin_skills"
+    romance = next(s for s in zh["skills"] if s["id"] == "romance-relationships")
+    assert romance["name"] == "恋爱与关系"
+    assert romance["description"].startswith("为以浪漫/亲密为核心的战役开启")
+    assert romance["content_rating"] == "mature"
+    assert romance["enabled"] is False
+
+    en = await admin.dispatch("keeper", "arkham", {"type": "admin_list_skills"}, get_i18n("en"))
+    assert en["type"] == "admin_skills"
+    romance_en = next(s for s in en["skills"] if s["id"] == "romance-relationships")
+    assert romance_en["name"] == "Romance & relationships"
+    assert romance_en["description"].startswith("Enable for a campaign centered on romance")
+
+
 async def test_admin_update_server_not_configured_is_rejected():
     services = _update_services("")  # feature off
     reply = await AdminService(services, Keystore()).dispatch(

--- a/tests/net/test_admin.py
+++ b/tests/net/test_admin.py
@@ -160,6 +160,14 @@ async def test_admin_skills_list_follows_the_caller_locale():
     assert romance_en["name"] == "Romance & relationships"
     assert romance_en["description"].startswith("Enable for a campaign centered on romance")
 
+    # A request-frame locale overrides the server locale: a Chinese-pinned client on an
+    # English-locale server must still get the localized list.
+    pinned = await admin.dispatch(
+        "keeper", "arkham", {"type": "admin_list_skills", "locale": "zh"}, get_i18n("en")
+    )
+    romance_pinned = next(s for s in pinned["skills"] if s["id"] == "romance-relationships")
+    assert romance_pinned["name"] == "恋爱与关系"
+
 
 async def test_admin_update_server_not_configured_is_rejected():
     services = _update_services("")  # feature off


### PR DESCRIPTION
## Summary

Two related problems on the KeeperSkills screen:

1. **No localization** — skill names/descriptions come from SKILL.md frontmatter, which only carried English display metadata; the server passed it through verbatim, so a Chinese-locale client saw a bare English list.
2. **Broken layout** — each row rendered `name · long description · content-rating · on/off` on one line inside a fixed-height list box; long descriptions wrapped and overflowed, and an empty content-rating left a stray `·` segment.

## Changes

- **`core/skills.py`**: parse optional `name-zh` / `description-zh` frontmatter (folded-block newlines stripped); English fields remain the fallback.
- **`skills/*`**: ship `name-zh` / `description-zh` for all seven built-in skills.
- **`KeeperSkills.tsx`**: render each row on one line (`truncate`); omit the content-rating segment when empty.
- **Protocol (`clients/protocol`)**: `admin_list_skills` / `admin_enable_skill` carry an optional `locale` field (additive; older servers ignore it).
- **Server (`net/admin.py`)**: the skills frame replies in the **requested** locale — the client's pinned UI language, which can differ from the server locale (a client can pin `zh` while the server runs its default `en`) — falling back to the server locale when the field is absent.
- **Tests**: localized-frontmatter parsing (with a guard that the metadata children are not swallowed), all built-in skills carry Chinese metadata, and the admin frame returns per-locale names (including the pinned-zh-client-on-en-server case).

## Verification

- `ruff check net/ tests/` — clean
- `python scripts/i18n_lint.py` — clean
- `pytest tests/core/test_skills.py tests/net/test_admin.py` — pass (full-suite delta vs baseline: zero new failures)
- `bun test` (tui) — 251 pass / 7 fail, identical to baseline (pre-existing harness failures)
