### PR TITLE
loop.py map; one home for room_rulepack / has_character; one roll-and-grade step

### DIFF
--- a/agent/card_text.py
+++ b/agent/card_text.py
@@ -34,6 +34,7 @@ from collections.abc import Callable
 from typing import Any
 
 from agent.services import Services
+from core.character_manager import has_character
 from core.documents import MODVARS_ID, MVU_ID, PLAYER_VIEWER
 from core.ejs_full import EjsFullError, FullEjsEngine, create_full_engine
 from core.ejs_lite import render as render_subset
@@ -45,7 +46,6 @@ from core.varspace import build_resolver, modvar_values_from_view
 # Mirrors `net.state.resolve_active_character`'s sentinel (agent must not import net):
 # `CharacterManager.get_character` resolves an unset active-character pointer to a fresh,
 # unsaved sheet named "default", so that name means "no character bound".
-_UNSET_CHARACTER_NAME = "default"
 
 
 async def _active_character_name(services: Services, uid: str, chat_key: str) -> str:
@@ -58,7 +58,7 @@ async def _active_character_name(services: Services, uid: str, chat_key: str) ->
         sheet = await services.characters.get_character(uid, chat_key)
     except Exception:
         return ""
-    if not sheet or not sheet.name or sheet.name == _UNSET_CHARACTER_NAME:
+    if not has_character(sheet):
         return ""
     return sheet.name
 

--- a/agent/kp_tools_charcard.py
+++ b/agent/kp_tools_charcard.py
@@ -28,7 +28,6 @@ from agent.char_from_persona import build_sheet_from_persona, infer_pronoun_note
 from agent.context import AgentCtx
 from agent.hook_runtime import install_room_hooks
 from agent.kp_tools_npc import player_name_refusal
-from agent.kp_tools_subsystems import room_rulepack
 from agent.services import Services
 from agent.tools import tool
 from core.card_split import WorldPayloads, card_hook_codes, detect_world_payloads, split_card
@@ -188,7 +187,7 @@ class CharcardTools:
                 ) or ""
             except Exception:
                 pack_system = ""
-            system = pack_system or (await room_rulepack(self._services, ctx)).system
+            system = pack_system or (await self._services.room_rulepack(ctx)).system
         if ctx.fs is None:
             return i18n.t("charcard.tools.import.no_fs")
         try:
@@ -365,7 +364,7 @@ class CharcardTools:
                     pin_system = pack_system
                     pinned_line = i18n.t("charcard.tools.world.system_pinned", system=pack_system)
                 else:
-                    pack = await room_rulepack(self._services, ctx)
+                    pack = await self._services.room_rulepack(ctx)
                     system = pack.system
 
             card, lorecard = _parse_any_card_file(host_path)

--- a/agent/kp_tools_companion.py
+++ b/agent/kp_tools_companion.py
@@ -29,7 +29,6 @@ from agent import npc as npc_records
 from agent.companion_actor import companion_action
 from agent.context import AgentCtx
 from agent.kp_tools_npc import player_name_refusal
-from agent.kp_tools_subsystems import room_rulepack
 from agent.services import Services
 from agent.tools import tool
 from core.character_manager import CharacterSheet
@@ -111,7 +110,7 @@ class CompanionTools:
         """
         i18n = self._i18n(ctx)
         try:
-            pack = await room_rulepack(self._services, ctx) if not system.strip() else load_rulepack(system)
+            pack = await self._services.room_rulepack(ctx) if not system.strip() else load_rulepack(system)
 
             # A companion is its record AND its sheet: a record whose sheet never landed is a
             # phantom `companion_act` would still drive (the 2026-08-18 《安土》 run's `npc-4`).

--- a/agent/kp_tools_mechanics.py
+++ b/agent/kp_tools_mechanics.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import json
 
 from agent.context import AgentCtx
+from agent.npc import list_companions
 from agent.services import Services, room_rule_variant
 from agent.tools import tool
 from core.battle_recording import record_check, record_dice_roll
@@ -45,6 +46,7 @@ from core.character_manager import (
     CharacterSheet,
     character_resources,
     get_hit_points,
+    has_character,
     set_hit_points,
 )
 from core.character_rules import render_validation_notice, validate_sheet
@@ -64,17 +66,11 @@ async def _get_active_character(services: Services, ctx: AgentCtx) -> CharacterS
 async def _sheet_pack(services: Services, ctx: AgentCtx, character: CharacterSheet) -> RulePack:
     """The rulepack governing `character`: its own system when resolvable,
     falling back to the room's active pack (bare/unset sheets)."""
-    from agent.kp_tools_subsystems import room_rulepack
 
     try:
         return load_rulepack(character.system)
     except Exception:
-        return await room_rulepack(services, ctx)
-
-
-def _has_character(character: CharacterSheet | None) -> bool:
-    """Whether `character` is a real (saved) character, not the `"default"` not-found placeholder."""
-    return bool(character) and character.name != "default"
+        return await services.room_rulepack(ctx)
 
 
 def _characteristic_lines(sheet: CharacterSheet, i18n: I18n, locale: str | None) -> tuple[list[str], list[str]]:
@@ -150,9 +146,8 @@ class CharacterTools:
             if system.strip():
                 pack = load_rulepack(system)
             else:
-                from agent.kp_tools_subsystems import room_rulepack
 
-                pack = await room_rulepack(self.services, ctx)
+                pack = await self.services.room_rulepack(ctx)
 
             if auto_generate:
                 character = self.services.characters.generate_character(pack.system, name)
@@ -195,7 +190,7 @@ class CharacterTools:
             character = await _get_active_character(self.services, ctx)
         except CharacterDataError:
             return i18n.t("kp_tools.character.data_error")
-        if not _has_character(character):
+        if not has_character(character):
             return i18n.t("kp_tools.character.none")
 
         lines = [
@@ -286,8 +281,6 @@ class CharacterTools:
         except Exception as exc:
             return i18n.t("kp_tools.character.list.failed", error=str(exc))
         try:
-            from agent.npc import list_companions
-
             companions = {
                 record.stat_char or record.name
                 for record in await list_companions(self.services.documents, ctx.chat_key)
@@ -304,7 +297,7 @@ class CharacterTools:
                 sheet = await characters.get_character(ctx.uid(), ctx.chat_key, name)
             except CharacterDataError:
                 continue  # one unreadable row must not cost the keeper the whole roster
-            if not _has_character(sheet):
+            if not has_character(sheet):
                 continue
             attribute_lines, meter_lines = _characteristic_lines(sheet, i18n, ctx.locale)
             header = i18n.t(
@@ -333,7 +326,7 @@ class CharacterTools:
         characters = self.services.characters
         try:
             character = await _get_active_character(self.services, ctx)
-            if not _has_character(character):
+            if not has_character(character):
                 return i18n.t("kp_tools.character.none")
 
             pack = await _sheet_pack(self.services, ctx, character)
@@ -370,7 +363,7 @@ class CharacterTools:
         characters = self.services.characters
         try:
             character = await _get_active_character(self.services, ctx)
-            if not _has_character(character):
+            if not has_character(character):
                 return i18n.t("kp_tools.character.none")
 
             pack = await _sheet_pack(self.services, ctx, character)
@@ -502,7 +495,7 @@ class CharacterTools:
 
         try:
             character = await _get_active_character(self.services, ctx)
-            if not _has_character(character):
+            if not has_character(character):
                 return i18n.t("kp_tools.character.none")
 
             await self.services.characters.sync_party_roster(ctx.chat_key, character, status_effects=effects)
@@ -623,9 +616,8 @@ class DiceTools:
 
     async def _pool_check(self, ctx: AgentCtx, i18n, params: dict, actor: str | None) -> str:
         """Graded pool check for parameterized systems, under the ROOM's pack."""
-        from agent.kp_tools_subsystems import room_rulepack
 
-        pack = await room_rulepack(self.services, ctx)
+        pack = await self.services.room_rulepack(ctx)
         resolver = pack.resolver
         if resolver is None or not resolver.params:
             return i18n.t("kp_tools.dice.pool.not_parameterized")
@@ -714,7 +706,7 @@ class DiceTools:
                 # the params ARE the whole input — no sheet required.
                 return await self._pool_check(ctx, i18n, params, actor)
             character = await _get_active_character(self.services, ctx)
-            if not _has_character(character):
+            if not has_character(character):
                 return i18n.t("kp_tools.character.none")
             display_name, is_npc = await _resolve_actor_identity(
                 self.services,
@@ -866,7 +858,7 @@ class DiceTools:
         characters = self.services.characters
         try:
             character = await _get_active_character(self.services, ctx)
-            if not _has_character(character):
+            if not has_character(character):
                 return i18n.t("kp_tools.character.none")
 
             hp, hp_max = get_hit_points(character)

--- a/agent/kp_tools_mechanics.py
+++ b/agent/kp_tools_mechanics.py
@@ -51,6 +51,7 @@ from core.character_manager import (
 )
 from core.character_rules import render_validation_notice, validate_sheet
 from core.check_outcome import CheckOutcome, outcome_wire
+from core.check_roll import favor_modifiers, graded_roll
 from core.dice_engine import DiceResult
 from core.rulepacks import RulePack, load_rulepack
 from core.sheets import check_value, has_check_value, set_sheet_value, sheet_value
@@ -733,22 +734,18 @@ class DiceTools:
                 return i18n.t("kp_tools.dice.skill_check.unknown_skill", name=skill_name)
             sheet_check_value = None if is_npc else check_value(character, pack, canonical)
 
-            # The pack routes the favorable/unfavorable counts to its declared
-            # roll modifiers; opposing counts cancel (net), and the engine
-            # replays multi-dice semantics for count-style modifiers.
+            # The pack routes the favorable/unfavorable counts to its declared roll
+            # modifiers (opposing counts cancel) — `core.check_roll`, shared with the
+            # typed-command lane so the two cannot drift on how a check is rolled.
             net_favor = bonus - penalty
-            modifiers: dict[str, int] = {}
-            favor_label = ""
-            if net_favor > 0 and check.favorable:
-                modifiers[check.favorable] = net_favor
-                favor_label = pack.display_name(check.favorable, ctx.locale)
-            elif net_favor < 0 and check.unfavorable:
-                modifiers[check.unfavorable] = -net_favor
-                favor_label = pack.display_name(check.unfavorable, ctx.locale)
+            modifiers, applied = favor_modifiers(check, bonus, penalty)
+            favor_label = pack.display_name(applied, ctx.locale) if applied else ""
 
             variant = await room_rule_variant(self.services.store, ctx.chat_key)
-            rolled = dice.roll_for_check(resolver, modifiers=modifiers or None)
 
+            # What the roll is graded against, and the flat sheet modifier — the tool
+            # lane's inputs (an explicit DC or the pack default; an NPC's stated number
+            # or the sheet's own value).
             if resolver.target_kind == "dc":
                 # Roll + sheet modifier against an external difficulty target.
                 target = int(dc) if dc is not None else int(check.default_target or 0)
@@ -760,10 +757,10 @@ class DiceTools:
                 target = int(npc_target) if is_npc else int(sheet_check_value or 0)
                 modifier = 0
 
-            outcome = resolver.interpret(rolled, target, variant=variant, modifier=modifier)
+            graded = graded_roll(dice, resolver, modifiers=modifiers, target=target, modifier=modifier, variant=variant)
+            rolled, outcome, total = graded.rolled, graded.outcome, graded.total  # graded: target is an int
             level_label = pack.rank_label(outcome.rank.id, ctx.locale)
             skill_label = pack.display_name(canonical, ctx.locale)
-            total = rolled.total + modifier
 
             prof_label = i18n.t("kp_tools.dice.skill_check.proficient_label") if proficient and check.proficiency else ""
             lines = [i18n.t("kp_tools.dice.skill_check.header", name=display_name, skill=skill_label, extra=prof_label)]

--- a/agent/kp_tools_subsystems.py
+++ b/agent/kp_tools_subsystems.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from agent.context import AgentCtx
 from agent.services import Services, room_rule_variant
-from core.character_manager import CharacterDataError, CharacterSheet
+from core.character_manager import CharacterDataError, CharacterSheet, has_character
 from core.check_outcome import RollDetail, outcome_wire
 from core.luck import adjust_check_with_luck, find_latest_character_check, is_luck_eligible_check
 from core.resolution import InvalidRollParamError, MissingRollParamError
@@ -26,38 +26,9 @@ from core.rulepacks import RulePack, load_rulepack
 from core.subsystems import SubsystemSpec
 from infra.i18n import I18n
 
-_UNSET_CHARACTER_NAME = "default"
-
 
 async def _active_character(services: Services, ctx: AgentCtx) -> CharacterSheet:
     return await services.characters.get_character(ctx.uid(), ctx.chat_key)
-
-
-def _has_character(character: CharacterSheet | None) -> bool:
-    return bool(character and character.name and character.name != _UNSET_CHARACTER_NAME)
-
-
-async def room_rulepack(services: Services, ctx: AgentCtx) -> RulePack:
-    """The rule system THIS room plays: the active character's system, then the
-    room's world-import system pin (`room_system`, written by `.import … world`
-    when the module's pack ships exactly one rulepack), then the deployment's
-    configured default pack."""
-    system = ""
-    try:
-        character = await _active_character(services, ctx)
-        if _has_character(character):
-            system = character.system
-    except Exception:
-        system = ""
-    if not system:
-        try:
-            system = await services.store.state_get(ctx.chat_key, "room_system") or ""
-        except Exception:
-            system = ""
-    try:
-        return load_rulepack(system or services.settings.default_rulepack)
-    except Exception:
-        return load_rulepack(services.settings.default_rulepack)
 
 
 # ---------------------------------------------------------------------------
@@ -240,7 +211,7 @@ async def _run_script_flow(services: Services, ctx: AgentCtx, i18n: I18n, spec: 
     from core.sheets import canonical_values, set_sheet_value, sheet_value
 
     character = await _active_character(services, ctx)
-    if not _has_character(character):
+    if not has_character(character):
         return i18n.t("kp_tools.character.none")
     pack = load_rulepack(character.system)
     if pack.subsystems.get(spec.id) is None:
@@ -299,7 +270,7 @@ async def _run_check_with_loss(
     services: Services, ctx: AgentCtx, i18n: I18n, spec: SubsystemSpec, success_loss: str, failure_loss: str, tag: str = ""
 ) -> str:
     character = await _active_character(services, ctx)
-    if not _has_character(character):
+    if not has_character(character):
         return i18n.t("kp_tools.character.none")
     pack = load_rulepack(character.system)
     if pack.subsystems.get(spec.id) is not spec and spec.id not in pack.subsystems:
@@ -420,7 +391,7 @@ async def _run_improvement_check(
     services: Services, ctx: AgentCtx, i18n: I18n, spec: SubsystemSpec, skill_name: str
 ) -> str:
     character = await _active_character(services, ctx)
-    if not _has_character(character):
+    if not has_character(character):
         return i18n.t("kp_tools.character.none")
 
     standard_name = services.characters.find_skill_by_alias(character, skill_name)
@@ -471,7 +442,7 @@ async def _run_resource_spend(
         points = points_raw
 
     active_character = await _active_character(services, ctx)
-    if not _has_character(active_character):
+    if not has_character(active_character):
         return i18n.t("kp_tools.character.none")
     pack = load_rulepack(active_character.system)
     if spec.id not in pack.subsystems or pack.resolver is None:
@@ -603,7 +574,7 @@ async def _run_opposed(
     services: Services, ctx: AgentCtx, i18n: I18n, spec: SubsystemSpec, arguments: dict[str, Any]
 ) -> str:
     character = await _active_character(services, ctx)
-    if not _has_character(character):
+    if not has_character(character):
         return i18n.t("kp_tools.character.none")
     pack = load_rulepack(character.system)
     resolver = pack.resolver

--- a/agent/loop.py
+++ b/agent/loop.py
@@ -156,7 +156,7 @@ from agent.history import (
     trim_folded,
 )
 from agent.hook_runtime import apply_hook_writes, load_room_hook_engine, record_hook_injections
-from agent.kp_tools_subsystems import dispatch_subsystem, room_rulepack, subsystem_schemas
+from agent.kp_tools_subsystems import dispatch_subsystem, subsystem_schemas
 from agent.prompt_builder import build_system_prompt_parts
 from agent.services import Services
 from agent.tool_phase import room_capabilities, room_phase
@@ -442,7 +442,7 @@ async def run_kp_turn(
     # Stage D tool materialization: the room's rulepack declares which subsystem
     # tools exist here (a system that declares none materializes none), and their
     # schemas ride alongside the static toolset for this turn.
-    room_pack = await room_rulepack(services, ctx)
+    room_pack = await services.room_rulepack(ctx)
     subsystem_tools = subsystem_schemas(room_pack)
 
     # M20 A2: history is APPEND-ONLY between folds — the sliding window is gone, because

--- a/agent/loop.py
+++ b/agent/loop.py
@@ -18,6 +18,114 @@ stays lean across turns. A keeper-only tool's raw result is recorded in
 ``role="tool"`` message; it is never surfaced as-is as ``reply`` (the model
 must transform it first, per the keeper-secrecy discipline block the system
 prompt carries — see ``agent/prompt_builder.py``).
+
+=====================================================================
+THE MAP — read this before changing anything below
+=====================================================================
+
+This module is the most paid-for code in the repo: nearly every block below
+exists because a live session broke without it, and the fix's reason is in
+the comment next to it. The line-level comments say WHY each piece is there;
+this section says HOW THE PIECES FIT, which is the thing a reader cannot
+recover from any one of them. Do not split this file for readability alone
+(owner ruling 2026-08-19): the pieces are kept together because their ORDER
+is the contract.
+
+How one turn runs (``run_kp_turn``), in order — every step depends on the
+ones above it:
+
+ 1. Reset per-turn residue on the (reused) ``AgentCtx``: dice payloads, NPC
+    lines, ``hook_injections`` / ``clock_advances`` / ``variable_writes``.
+ 2. Fire the ``turn_start`` hook BEFORE prompt assembly — its injections and
+    variable writes must shape this very prompt.
+ 3. Adopt legacy history (``migrate_legacy_blob``), then run the routine
+    chronicle fold (``maybe_fold_chronicle``) — also BEFORE assembly, so the
+    emergency ceiling keeps headroom for the fold's own generation.
+ 4. Fix this turn's tool catalog ONCE: ``unlocked`` (skills), ``phase``
+    (prep/play), ``capabilities`` (room stores), ``room_pack`` subsystem
+    tools. Every schema build and every dispatch this turn uses the same
+    four values, so what is offered and what is refused can never disagree.
+ 5. Assemble the prompt (``_assemble_base``): stable head as ONE system
+    message with a cache breakpoint; replayed history (trimmed to what the
+    fold has absorbed); the volatile state tail as a USER message headed as
+    engine state; the player line. One assembler, one object (iron rule #5);
+    two wire slots for cache behavior (M20 A1).
+ 6. Stamp ``turn_index`` (= completed turns + 1, the same stamp chronicle
+    records use), heal a crashed prior attempt's dangling leaf (NOT inside a
+    companion sub-turn), write down the hook injections (M23 WS3), and
+    persist the PLAYER message NOW — so a nested companion turn appends its
+    exchange between the player's line and the reply, the order the table saw.
+ 7. The round loop: ``chat`` → if tool calls, ``_dispatch_and_record`` and go
+    again; else the content is the reply. A context overflow — refusal OR a
+    reply truncated at the window — folds once and retries ONCE
+    (``_recover_from_overflow``); any other provider error returns a
+    localized diagnosis WITHOUT persisting the turn (the player line is
+    abandoned back off the path).
+ 8. End-of-turn checks (``_run_turn_checks``): the pack-declared Stop-form
+    table, re-verified after every re-ask, bounded by
+    ``MAX_ROUNDS_PER_TURN``; a tool round inside a check is not the end
+    (the narration that reads the real roll is).
+ 9. If ``max_rounds`` ran out with no plain reply: one tools-disabled
+    finalizer over the public committed results, else the deterministic
+    fallback.
+10. Reply post-processing, in THIS order: MVU ``<UpdateVariable>`` blocks
+    applied + stripped (deterministic code does the bookkeeping) → text-shaped
+    tool calls stripped → reply hooks (``apply``/``reply`` phases) →
+    ``output_review`` (the censor sees final text) → stream gate drained.
+11. Persist the reply, advance the chronicle counter, photograph the room for
+    undo (``capture_snapshot`` AFTER the counter, so snapshot ``turn_index``
+    is the end-of-turn state), fill an estimated prompt size if the provider
+    reported none.
+
+Invariants a change here must keep (each one was paid for — see the comment
+at the site, and ``docs/defensive-patterns.md``):
+
+ * ``messages`` is mutated IN PLACE for the whole turn and never rebound: the
+   provider's continuation state (``_clear_llm_continuation``) is keyed by the
+   list's identity. The overflow rebuild splices (``messages[:] = ...``).
+ * Cache breakpoints are wire-only marks on COPIES; the persisted chain never
+   carries ``CACHE_BREAKPOINT_KEY``. Exactly one breakpoint rides the newest
+   tool result (``_move_in_turn_breakpoint``); calls that leave the main
+   prefix (checks, finalizer) strip the marks.
+ * The overflow retry is at most once per KP turn and only if the fold FOLDED
+   something — no progress, no retry (the ping-pong guard). The retry is
+   budgeted as +1 round, not as a tool round.
+ * Provider errors never crash a turn and never persist one; cancellation
+   (``asyncio.CancelledError``) always releases continuation state before it
+   propagates.
+ * Tool calls in one round run concurrently ONLY when every one is
+   ``read_only`` — two writers racing on one document is a lost update, not a
+   speedup. ``speak_as_npc`` / ``companion_act`` are never read-only.
+ * The stream gate is fail-closed: text leaves for the client only once it can
+   no longer become part of a machinery/MVU block; a tool round's draft is
+   discarded; the final ``narrative`` frame is authoritative. Streaming the
+   final draft happens BEFORE the check lane so a corrective roll can close it.
+ * Tool results are capped (``MAX_TOOL_RESULT_CHARS``) and the cut is ANNOUNCED
+   to the model — a silent cut makes it answer from half a document.
+ * Nothing here is a new model-call lane: the turn's budget is
+   ``AGENTS.md`` "Per-turn model-call budget", pinned by
+   ``tests/agent/test_turn_call_budget.py``. The check runner's calls are
+   deliberately NOT folded into the headline usage.
+ * Hook failures never break a turn; hook emissions are capped
+   (``MAX_PANEL_EVENTS_PER_TURN``).
+ * ``ctx.platform == "companion"`` marks a NESTED turn: no dangling-leaf heal,
+   no Scribe/Director (those guards live in ``gateway/turn.py`` and
+   ``gateway/director.py``), and it deliberately does NOT take the room's
+   turn lock — that is what keeps it from self-deadlocking.
+
+Traps (things that look like small improvements and are not):
+
+ * "This round also needs to do one small thing" — a new per-turn step goes
+   in the phase list above or in ``agent/turn_checks`` (the declarative
+   table), not as a sixth ad-hoc branch in the round loop.
+ * Folding the check runner's usage into ``turn_usage`` (it is a bounded
+   repair pass, and the meter drives the fold).
+ * Re-ordering step 11: the reply is persisted FIRST (it carries this turn's
+   stamp), the counter advances SECOND, the undo snapshot is taken LAST
+   (before the counter it would be named one turn off).
+ * Reading a chronicle/turn index AFTER ``run_kp_turn`` returns by re-reading
+   the counter — take it from ``KPTurnResult.turn`` (M21 trap).
+ * Re-ordering step 10: the censor must see what the player will see.
 """
 
 from __future__ import annotations

--- a/agent/services.py
+++ b/agent/services.py
@@ -12,14 +12,16 @@ import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from agent.context import AgentCtx
 from agent.document_manager import VectorDatabaseManager
 from agent.module_initializer import ModuleInitializer
 from agent.tool_trace import enable_tool_trace
 from core.battle_report import BattleReportManager
-from core.character_manager import CharacterManager
+from core.character_manager import CharacterManager, has_character
 from core.dice_engine import DiceRoller
 from core.dice_engine import config as dice_config
 from core.documents import DocumentStore
+from core.rulepacks import RulePack, load_rulepack
 from core.worldbook import Worldbook
 from infra.config import Settings, get_settings
 from infra.embeddings import Embeddings, OpenAIEmbeddings
@@ -59,6 +61,30 @@ class Services:
     # One deployment-wide mutation lock shared by TUI admin frames, chat `.model`
     # commands, and subscription refresh publication. Room turn locks remain separate.
     config_lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
+
+    async def room_rulepack(self, ctx: AgentCtx) -> RulePack:
+        """The rule system THIS room plays: the active character's system, then the
+        room's world-import system pin (`room_system`, written by `.import … world`
+        when the module's pack ships exactly one rulepack), then the deployment's
+        configured default pack. The ONE answer to "which pack is this room on" —
+        every command and tool asks here (it used to be a function-level import in
+        eight places)."""
+        system = ""
+        try:
+            character = await self.characters.get_character(ctx.uid(), ctx.chat_key)
+            if has_character(character):
+                system = character.system
+        except Exception:
+            system = ""
+        if not system:
+            try:
+                system = await self.store.state_get(ctx.chat_key, "room_system") or ""
+            except Exception:
+                system = ""
+        try:
+            return load_rulepack(system or self.settings.default_rulepack)
+        except Exception:
+            return load_rulepack(self.settings.default_rulepack)
 
 
 def build_services(

--- a/core/character_manager.py
+++ b/core/character_manager.py
@@ -44,6 +44,17 @@ class CharacterDataError(Exception):
         super().__init__(message or f"character data for {char_name!r} is unreadable")
 
 
+# The fixed slot `get_character` falls back to when a user has no active character:
+# a sheet named this is the NOT-FOUND placeholder, never a real character.
+UNSET_CHARACTER_NAME = "default"
+
+
+def has_character(sheet: CharacterSheet | None) -> bool:
+    """Whether `sheet` is a real (saved) character rather than `get_character`'s
+    not-found placeholder. The ONE predicate every "is there a sheet?" check uses."""
+    return bool(sheet) and bool(sheet.name) and sheet.name != UNSET_CHARACTER_NAME
+
+
 class CharacterNameTakenError(Exception):
     """A sheet write would land on a character owned by a DIFFERENT user.
 
@@ -333,9 +344,9 @@ class CharacterManager:
         if not char_name:
             try:
                 active_name = await self.store.state_get(chat_key, f"active_character.{user_id}")
-                char_name = active_name if active_name else "default"
+                char_name = active_name if active_name else UNSET_CHARACTER_NAME
             except Exception:
-                char_name = "default"
+                char_name = UNSET_CHARACTER_NAME
 
         try:
             doc = await self.documents.get(chat_key, "sheet", char_name)

--- a/core/check_roll.py
+++ b/core/check_roll.py
@@ -1,0 +1,82 @@
+"""The one ROLL-and-GRADE step both check lanes share.
+
+A player's typed check (`gateway.commands.checks`) and the Keeper's `skill_check` tool
+(`agent.kp_tools_mechanics`) parse different inputs, render different text and publish
+different events — but between those two ends they do the same three things: route the
+favorable/unfavorable counts to the pack's declared roll modifiers, roll through the
+resolver, grade the roll against the target. That middle used to be written out twice;
+it lives here so the two lanes cannot drift on how a check is rolled and graded
+(iron rule #1 — the dice and the grading are deterministic code, once).
+
+Deliberately narrow: the lanes still decide WHAT the target and sheet modifier are (a
+typed temporary value, an explicit DC, an NPC's stated number, the sheet's own value)
+and they still own their events, records and wording. `graded_roll` is the step in
+between, nothing more.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from core.check_outcome import CheckOutcome, RollDetail
+from core.resolution import CheckResolver, CheckSpec
+
+
+def favor_modifiers(check: CheckSpec, bonus: int, penalty: int) -> tuple[dict[str, int], str]:
+    """Net the favorable/unfavorable counts onto the pack's declared modifier NAMES.
+
+    Returns ``(modifiers, applied)``: the mapping `roll_for_check` takes, and the name
+    of the modifier that ended up applied (``""`` when the counts cancel or the pack
+    declares none), for the lane that wants to say so. Opposing counts cancel: two
+    bonus and one penalty is one bonus, never both.
+    """
+    net = int(bonus) - int(penalty)
+    if net > 0 and check.favorable:
+        return {check.favorable: net}, check.favorable
+    if net < 0 and check.unfavorable:
+        return {check.unfavorable: -net}, check.unfavorable
+    return {}, ""
+
+
+@dataclass(frozen=True)
+class GradedRoll:
+    """One rolled-and-graded check. ``outcome`` is ``None`` for an UNGRADED roll — a
+    modifier-style system rolled with no target declared, which the lane shows as a
+    bare number rather than a rank."""
+
+    rolled: RollDetail
+    total: int  # the roll plus the lane's sheet modifier — what the target was compared to
+    target: int | None
+    effective_target: int | None  # the difficulty-adjusted target, when one applied
+    outcome: CheckOutcome | None
+
+
+def graded_roll(
+    dice,
+    resolver: CheckResolver,
+    *,
+    modifiers: dict[str, int] | None,
+    target: int | None,
+    modifier: int = 0,
+    variant: str | None = None,
+    difficulty: str | None = None,
+) -> GradedRoll:
+    """Roll through ``resolver`` with ``modifiers`` and grade against ``target``.
+
+    ``modifier`` is the lane's flat sheet modifier for roll-plus-modifier systems (the
+    d20 family); roll-under systems pass 0. ``difficulty`` is a pack-declared difficulty
+    id (the typed lane's `/hard`, `/extreme`); the tool lane passes none. A ``target`` of
+    ``None`` rolls without grading.
+    """
+    rolled = dice.roll_for_check(resolver, modifiers=modifiers or None)
+    total = rolled.total + int(modifier)
+    if target is None:
+        return GradedRoll(rolled=rolled, total=total, target=None, effective_target=None, outcome=None)
+    outcome = resolver.interpret(rolled, target, variant=variant, difficulty=difficulty, modifier=modifier)
+    return GradedRoll(
+        rolled=rolled,
+        total=total,
+        target=target,
+        effective_target=resolver.effective_target(target, difficulty=difficulty),
+        outcome=outcome,
+    )

--- a/gateway/avatar.py
+++ b/gateway/avatar.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from agent import npc as npc_records
 from agent.services import Services
-from core.character_manager import CharacterDataError, CharacterSheet
-
-_UNSET_CHARACTER_NAME = "default"
+from core.character_manager import CharacterDataError, CharacterSheet, has_character
 
 
 class AvatarError(ValueError):
@@ -29,7 +28,7 @@ async def set_user_avatar(
         # An unreadable row cannot safely carry an avatar update (saving would
         # overwrite it); surface it through the transport-handled AvatarError.
         raise AvatarError("avatar_no_character") from exc
-    if not sheet or not sheet.name or sheet.name == _UNSET_CHARACTER_NAME:
+    if not has_character(sheet):
         raise AvatarError("avatar_no_character")
     sheet.avatar = avatar
     await services.characters.save_character(user_id, chat_key, sheet)
@@ -43,8 +42,6 @@ async def set_target_avatar(
     target: str,
     avatar: dict[str, Any] | None,
 ) -> CharacterSheet:
-    from agent import npc as npc_records
-
     record = await npc_records.get_npc(services.documents, chat_key, target)
     if record is None or not record.stat_char:
         raise AvatarError("avatar_target_not_found")
@@ -55,7 +52,7 @@ async def set_target_avatar(
             sheet = await services.characters.get_character(user_id, chat_key, record.stat_char)
         except CharacterDataError:
             continue
-        if sheet and sheet.name and sheet.name != _UNSET_CHARACTER_NAME:
+        if has_character(sheet):
             sheet.avatar = avatar
             await services.characters.save_character(user_id, chat_key, sheet)
             return sheet

--- a/gateway/commands/cast.py
+++ b/gateway/commands/cast.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from agent import npc as npc_records
 from agent.context import AgentCtx
 from gateway.commands.rooms import _is_keeper
 from gateway.commands.types import CommandCtx
@@ -107,8 +108,6 @@ class CastCommands:
         `secret_agenda` and an NPC's private knowledge live in them), so every subcommand is
         keeper-only and the reply is private — `show` prints the full record, listings do not.
         """
-        from agent import npc as npc_records
-
         if not _is_keeper(ctx.raw_ctx):
             return ctx.fail(ctx.i18n.t("rooms.denied"))
         companions_only = ctx.spec.canonical == "companion"

--- a/gateway/commands/checks.py
+++ b/gateway/commands/checks.py
@@ -194,9 +194,8 @@ async def _pack_for_character(ctx: CommandCtx, character: CharacterSheet) -> Rul
     try:
         return load_rulepack(character.system)
     except Exception:
-        from agent.kp_tools_subsystems import room_rulepack
 
-        return await room_rulepack(ctx.services, ctx.raw_ctx)
+        return await ctx.services.room_rulepack(ctx.raw_ctx)
 
 
 def _consume_bonus_penalty(text: str, bonus: int, penalty: int) -> tuple[str, int, int]:

--- a/gateway/commands/checks.py
+++ b/gateway/commands/checks.py
@@ -15,6 +15,7 @@ from core.character_manager import (
     CharacterSheet,
 )
 from core.check_outcome import CheckOutcome, outcome_wire
+from core.check_roll import favor_modifiers, graded_roll
 from core.dice_engine import DiceResult
 from core.resolution import InvalidRollParamError, MissingRollParamError, ResolutionError
 from core.rulepacks import RulePack, load_rulepack
@@ -527,14 +528,10 @@ class ChecksCommands:
         times, rest = _split_multi(args)
         parsed = _parse_check_args(rest, pack, default_name=check.default_skill)
         variant = await _get_rule_variant(ctx)
+        modifiers, _applied = favor_modifiers(check, parsed.bonus, parsed.penalty)
 
-        modifiers: dict[str, int] = {}
-        favor_net = parsed.bonus - parsed.penalty
-        if favor_net > 0 and check.favorable:
-            modifiers[check.favorable] = favor_net
-        elif favor_net < 0 and check.unfavorable:
-            modifiers[check.unfavorable] = -favor_net
-
+        # What the roll is graded against, and the flat sheet modifier — the typed
+        # lane's inputs (a temporary value, an explicit DC, the sheet's own value).
         if resolver.target_kind == "dc":
             target_value = parsed.temp_value  # explicit target; None = ungraded roll
             modifier = check_value(character, pack, parsed.canonical)
@@ -544,17 +541,20 @@ class ChecksCommands:
             target_value = _target_value(character, pack, parsed.canonical, parsed.temp_value)
             modifier = 0
 
-        effective_target = (
-            resolver.effective_target(target_value, difficulty=parsed.difficulty)
-            if target_value is not None
-            else None
-        )
         display_name = pack.display_name(parsed.canonical, ctx.locale)
         lines = []
         for _ in range(min(times, 20)):
-            rolled = ctx.services.dice.roll_for_check(resolver, modifiers=modifiers or None)
-            total = rolled.total + modifier
-            if target_value is None:
+            graded = graded_roll(
+                ctx.services.dice,
+                resolver,
+                modifiers=modifiers,
+                target=target_value,
+                modifier=modifier,
+                variant=variant,
+                difficulty=parsed.difficulty,
+            )
+            rolled, total, outcome = graded.rolled, graded.total, graded.outcome
+            if outcome is None:
                 # No target declared for a modifier-style system: show the roll.
                 ctx.dice(
                     "check",
@@ -574,9 +574,6 @@ class ChecksCommands:
                     )
                 )
                 continue
-            outcome = resolver.interpret(
-                rolled, target_value, variant=variant, difficulty=parsed.difficulty, modifier=modifier
-            )
             label = pack.rank_label(outcome.rank.id, ctx.locale)
             ctx.dice(
                 "check",
@@ -585,7 +582,7 @@ class ChecksCommands:
                 rolls=[rolled.total],
                 total=total,
                 target=target_value,
-                effective_target=effective_target,
+                effective_target=graded.effective_target,
                 outcome=outcome_wire(outcome, label),
                 detail={"modifier": modifier, **dict(rolled.modifiers)},
             )
@@ -608,7 +605,7 @@ class ChecksCommands:
                     "commands.check.result",
                     name=display_name,
                     target=target_value,
-                    effective=effective_target,
+                    effective=graded.effective_target,
                     roll=total,
                     rank=label,
                 )

--- a/gateway/commands/media.py
+++ b/gateway/commands/media.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import shlex
 from typing import Any
 
+from agent import npc as npc_records
 from gateway.audio import add_audio_item, build_audio_control, list_audio_items, resolve_audio_item, update_audio_item
 from gateway.avatar import AvatarError, set_target_avatar, set_user_avatar
 from gateway.commands.rooms import _is_keeper
@@ -41,8 +42,6 @@ def _shell_words(text: str) -> list[str]:
 
 async def _resolve_avatar_target(ctx: CommandCtx, target: str) -> Any | None:
     try:
-        from agent import npc as npc_records
-
         return await npc_records.get_npc(ctx.services.documents, ctx.chat_key, target)
     except Exception:
         return None

--- a/gateway/commands/rules.py
+++ b/gateway/commands/rules.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from agent.kp_tools_subsystems import dispatch_subsystem
 from agent.services import set_room_rule_variant
 from agent.tool_phase import PHASES, is_pinned, room_phase, set_room_phase
 from core.skills import available_skills
@@ -54,9 +55,8 @@ class RulesCommands:
         it; checks then grade under the default ladder). Changing the ladder
         regrades EVERY member's checks (a house rule), so the write is
         keeper-gated in-handler — matching ``.bot``."""
-        from agent.kp_tools_subsystems import room_rulepack
 
-        pack = await room_rulepack(ctx.services, ctx.raw_ctx)
+        pack = await ctx.services.room_rulepack(ctx.raw_ctx)
         resolver = pack.resolver
         known = set(resolver.variant_ids()) if resolver is not None else set()
         raw = ctx.args.strip().casefold()
@@ -89,14 +89,13 @@ class RulesCommands:
         not have the command (stage D materialization at the command layer).
         Exception: a make-char word is the ENTRY POINT into the pack that
         declares it, so it resolves across all installed packs."""
-        from agent.kp_tools_subsystems import dispatch_subsystem, room_rulepack
         from core.rulepacks import pack_declaring_command
 
         maker = pack_declaring_command(ctx.spec.canonical, "make_char")
         if maker is not None:
             return await self.cmd_make_char(ctx, maker)
 
-        pack = await room_rulepack(ctx.services, ctx.raw_ctx)
+        pack = await ctx.services.room_rulepack(ctx.raw_ctx)
         binding = pack.commands.get(ctx.spec.canonical)
         if binding is None:
             return ctx.i18n.t("commands.pack_word.not_in_system", word=ctx.spec.canonical)

--- a/gateway/commands/sheet.py
+++ b/gateway/commands/sheet.py
@@ -296,9 +296,8 @@ class SheetCommands:
         command word routed here — the word set itself is pack data), falling
         back to the room's active system."""
         if pack is None:
-            from agent.kp_tools_subsystems import room_rulepack
 
-            pack = await room_rulepack(ctx.services, ctx.raw_ctx)
+            pack = await ctx.services.room_rulepack(ctx.raw_ctx)
         name = ctx.args.strip() or ctx.i18n.t("commands.character.default_name")
         character = ctx.services.characters.generate_character(pack.system, name)
         character, violations = validate_sheet(
@@ -329,9 +328,8 @@ class SheetCommands:
             return ctx.i18n.t("charcard.commands.genchar.usage")
         system = request.system
         if not system:
-            from agent.kp_tools_subsystems import room_rulepack
 
-            system = (await room_rulepack(ctx.services, ctx.raw_ctx)).system
+            system = (await ctx.services.room_rulepack(ctx.raw_ctx)).system
 
         character = await build_sheet_from_description(
             ctx.services,

--- a/net/state.py
+++ b/net/state.py
@@ -26,13 +26,12 @@ import json
 from typing import Any
 
 from agent.context import AgentCtx
+from agent.npc import list_companions
 from agent.services import Services
-from core.character_manager import CharacterSheet, character_resources, resource_label_map
+from core.character_manager import CharacterSheet, character_resources, has_character, resource_label_map
 from core.documents import KEEPER_VIEWER, MODULE_POOL_ID, MVU_ID, PLAYER_VIEWER, SCENE_ID
 from core.modvars import MODVARS_DOC_ID, MODVARS_DOC_TYPE, wire_entries
 from infra.usage_stats import USAGE_STATS_KEY
-
-_UNSET_CHARACTER_NAME = "default"
 
 
 async def build_room_state(services: Services, ctx: AgentCtx) -> dict[str, Any]:
@@ -131,7 +130,7 @@ async def resolve_active_character(services: Services, ctx: AgentCtx) -> Charact
         sheet = await services.characters.get_character(ctx.uid(), ctx.chat_key)
     except Exception:
         return None
-    if not sheet or not sheet.name or sheet.name == _UNSET_CHARACTER_NAME:
+    if not has_character(sheet):
         return None
     return sheet
 
@@ -279,8 +278,6 @@ def _int_value(value: Any) -> int | None:
 async def _companion_sheet_names(services: Services, chat_key: str) -> set[str]:
     """Character-sheet names belonging to AI player companions in this room (best-effort, may be empty)."""
     try:
-        from agent.npc import list_companions
-
         records = await list_companions(services.documents, chat_key)
     except Exception:
         return set()

--- a/tests/agent/test_f20_regressions.py
+++ b/tests/agent/test_f20_regressions.py
@@ -25,7 +25,7 @@ import pytest
 from agent.context import AgentCtx
 from agent.hook_runtime import apply_hook_writes, load_room_hook_engine
 from agent.kp_tools import build_kp_toolset
-from agent.kp_tools_subsystems import dispatch_subsystem, room_rulepack
+from agent.kp_tools_subsystems import dispatch_subsystem
 from agent.services import build_services
 from core.dice_engine import seed_dice
 from core.modvars import define_modvar
@@ -62,7 +62,7 @@ async def test_a_failed_loss_check_deducts_and_the_panel_shows_it_the_same_turn(
     assert _panel(await build_room_state(services, ctx))["san"] == 50
 
     seed_dice(FAILING_SEED)
-    pack = await room_rulepack(services, ctx)
+    pack = await services.room_rulepack(ctx)
     reply = await dispatch_subsystem(
         services, ctx, pack, "sanity_check", {"success_loss": "0", "failure_loss": "1d6"}
     )
@@ -87,7 +87,7 @@ async def test_a_zero_failure_cost_is_stated_instead_of_looking_like_a_broken_en
     services, ctx = await _room()
 
     seed_dice(FAILING_SEED)
-    pack = await room_rulepack(services, ctx)
+    pack = await services.room_rulepack(ctx)
     reply = await dispatch_subsystem(
         services, ctx, pack, "sanity_check", {"success_loss": "0", "failure_loss": "0"}
     )
@@ -103,7 +103,7 @@ async def test_a_successful_check_with_a_zero_success_cost_says_nothing_unusual(
     services, ctx = await _room()
 
     seed_dice(PASSING_SEED)
-    pack = await room_rulepack(services, ctx)
+    pack = await services.room_rulepack(ctx)
     reply = await dispatch_subsystem(
         services, ctx, pack, "sanity_check", {"success_loss": "0", "failure_loss": "1d6"}
     )

--- a/tests/agent/test_world_import_system_pin.py
+++ b/tests/agent/test_world_import_system_pin.py
@@ -17,7 +17,6 @@ import pytest
 import core.rulepacks as rulepacks_module
 from agent.context import AgentCtx, LocalFs
 from agent.kp_tools_charcard import CharcardTools
-from agent.kp_tools_subsystems import room_rulepack
 from agent.services import build_services
 from core.pregen_roster import pregen_entries
 from infra.config import Settings
@@ -103,7 +102,7 @@ async def test_sole_rulepack_pack_pins_the_room_system(tmp_path, user_rulepack_d
     roster = await pregen_entries(services.documents, "pin-room")
     assert roster and roster[0]["system"] == "harbour-tides"
     # No character claimed yet: the room's rulepack now follows the pin.
-    pack = await room_rulepack(services, ctx)
+    pack = await services.room_rulepack(ctx)
     assert pack.system == "harbour-tides"
 
 
@@ -135,7 +134,7 @@ async def test_among_several_rulepacks_the_one_that_creates_characters_is_the_pi
 
     assert "harbour-crew" in reply
     assert await services.store.state_get("crew-room", "room_system") == "harbour-crew"
-    assert (await room_rulepack(services, ctx)).system == "harbour-crew"
+    assert (await services.room_rulepack(ctx)).system == "harbour-crew"
 
 
 async def test_two_character_systems_in_one_pack_stay_ambiguous(tmp_path, user_rulepack_dir):

--- a/tests/core/test_check_roll.py
+++ b/tests/core/test_check_roll.py
@@ -1,0 +1,35 @@
+"""core.check_roll — the roll-and-grade step both check lanes share."""
+
+from __future__ import annotations
+
+from core.check_roll import favor_modifiers, graded_roll
+from core.dice_engine import DiceRoller, seed_dice
+from core.rulepacks import load_rulepack
+
+
+def test_favor_modifiers_nets_the_counts_onto_the_packs_declared_names():
+    check = load_rulepack("coc7").resolver.check
+    assert favor_modifiers(check, 2, 0) == ({check.favorable: 2}, check.favorable)
+    assert favor_modifiers(check, 0, 1) == ({check.unfavorable: 1}, check.unfavorable)
+    assert favor_modifiers(check, 2, 1) == ({check.favorable: 1}, check.favorable)  # opposing counts cancel
+    assert favor_modifiers(check, 1, 1) == ({}, "")
+
+
+def test_graded_roll_grades_against_the_target_and_reports_the_effective_one():
+    pack = load_rulepack("coc7")
+    dice = DiceRoller()
+    seed_dice(7)
+    graded = graded_roll(dice, pack.resolver, modifiers={}, target=60, difficulty="hard")
+    assert graded.target == 60 and graded.effective_target == 30  # coc7 hard = half
+    assert graded.outcome is not None and graded.outcome.target == 60  # the raw target rides the outcome
+    assert graded.outcome.rank.success is (graded.rolled.total <= 30)  # graded against the EFFECTIVE one
+    assert graded.total == graded.rolled.total  # roll-under: no flat modifier
+
+
+def test_graded_roll_without_a_target_is_ungraded():
+    pack = load_rulepack("dnd5e")
+    dice = DiceRoller()
+    seed_dice(3)
+    graded = graded_roll(dice, pack.resolver, modifiers={}, target=None, modifier=4)
+    assert graded.outcome is None and graded.effective_target is None
+    assert graded.total == graded.rolled.total + 4


### PR DESCRIPTION
## Summary
Follow-ups from the 2026-08-19 whole-repo review, owner-approved:

- **`agent/loop.py` gets its map** (docstring only, no code): the eleven steps of a KP turn in dependency order, the invariants a change must keep, and the traps that look like small improvements. The file stays whole by ruling; the map is what a reader could not recover from the line-level comments.
- **One home, not eight/five copies**: `Services.room_rulepack(ctx)` replaces `agent.kp_tools_subsystems.room_rulepack` (8 function-level imports); `core.character_manager.has_character` + `UNSET_CHARACTER_NAME` replace five copies of the `"default"`-placeholder predicate; every remaining function-level import of `agent.npc` / `kp_tools_subsystems` hoisted (no cycle ever forced them).
- **One roll-and-grade step for both check lanes**: `core.check_roll.favor_modifiers` + `graded_roll` — the typed `.ra` and the Keeper's `skill_check` still own their inputs, events and wording, but roll and grade through the same code. Unit tests for the kernel; both lanes' existing tests unchanged.

## Test plan
- [x] ruff / i18n lint clean
- [x] `uv run pytest` — 2559 passed
- [ ] CI green