### PR TITLE
panels: one vector table for template instantiation, consumed by engine and reference client

### DIFF
--- a/clients/tui/src/panelTemplates.vectors.test.ts
+++ b/clients/tui/src/panelTemplates.vectors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import type { ModuleVariable, PanelTemplateBlock, UiBlock } from "loreweaver-protocol"
+import { resolvePanelBlocks } from "./panelTemplates"
+
+// The TypeScript half of the panel template-instantiation conformance suite.
+//
+// `tests/fixtures/panel_template_vectors.json` is the SHARED table: the same rows run
+// here and in `tests/core/test_panel_template_vectors.py`. A panel is instantiated in
+// every client AND on the server (the `.panel` text fallback), so "every implementation
+// agrees with the reference one" is a promise only a shared fixture can keep — a row
+// that moves breaks both suites at once. THIS file is the reference side: the engine
+// mirrors `resolvePanelBlocks`, not the other way round.
+
+const VECTORS_PATH = fileURLToPath(new URL("../../../tests/fixtures/panel_template_vectors.json", import.meta.url))
+const vectors = JSON.parse(readFileSync(VECTORS_PATH, "utf-8")) as {
+  cases: Array<{
+    id: string
+    why: string
+    blocks: PanelTemplateBlock[]
+    variables: ModuleVariable[]
+    locale: string
+    expect: UiBlock[]
+  }>
+}
+
+describe("panel template conformance vectors", () => {
+  test("the shared table is actually loaded", () => {
+    expect(vectors.cases.length).toBeGreaterThanOrEqual(30)
+    // Rows that resolve to nothing are half the contract; rows that resolve to something
+    // are the other half. A table of only one kind would pass a resolver that always
+    // returned [].
+    expect(vectors.cases.some((row) => row.expect.length === 0)).toBe(true)
+    expect(vectors.cases.some((row) => row.expect.length > 1)).toBe(true)
+  })
+
+  for (const row of vectors.cases) {
+    test(`${row.id} — ${row.why}`, () => {
+      expect(resolvePanelBlocks(row.blocks, row.variables, row.locale)).toEqual(row.expect)
+    })
+  }
+})

--- a/core/panels.py
+++ b/core/panels.py
@@ -35,6 +35,11 @@ Template additions over the v1.7 block vocabulary (deliberately tiny):
   validates syntax AND portability (`core.condexpr.check_subset`), so an expression a
   second client implementation could read differently never ships.
 
+Instantiating those templates for ONE viewer — bindings substituted, gates evaluated,
+repeats expanded — is :func:`resolve_panel_blocks`, which mirrors the reference client
+(`clients/tui/src/panelTemplates.ts`) rule for rule;
+``tests/fixtures/panel_template_vectors.json`` is the table both implementations run.
+
 The privilege model stays one sentence long: a panel acts as the player viewing it.
 ``audience`` is resolved server-side into per-viewer manifests and never rides the
 wire; a keeper-only panel structurally never enters a player's manifest.
@@ -42,6 +47,7 @@ wire; a keeper-only panel structurally never enters a player's manifest.
 
 from __future__ import annotations
 
+import math
 import posixpath
 import re
 from collections.abc import Mapping, Sequence
@@ -516,146 +522,361 @@ def parse_panels_text(text: str) -> tuple[PanelSpec, ...]:
     return panels
 
 
-# --- Text rendering (protocol-client / terminal fallback) --------------------
+# --- Template instantiation, then text rendering ----------------------------
 #
-# A tier-2 panel's `fallback` exists for exactly one purpose: to be READ by a client
-# that cannot render the rich page. Until this function existed nothing could turn it
-# into text — a 2026-08-18 play-test found `.panel` produced no frame at all, so a
-# module's look-at-the-chart clues (its whole ◈ layer) were unreachable on a terminal.
-# Pure and here rather than in a client because this module already owns the template
-# semantics both sides implement: `$var` substitution, absent-means-hide, `repeat`, and
-# `visible_when` through `core.condexpr` — the same evaluator the portability check
-# validates against at build time, so a server-rendered panel and a client-rendered one
-# cannot disagree about what is visible.
-
-MAX_TEXT_REPEAT_INSTANCES = MAX_REPEAT_INSTANCES
-
-# Per kind: (required, optional) template fields, mirroring `clients/tui/src/panelTemplates.ts`
-# — a required binding that misses drops the block, an optional one drops only itself.
-_TEXT_FIELDS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
-    "meter": (("label", "value", "min", "max"), ()),
-    "stat": (("label", "value"), ()),
-    "badge": (("label",), ("tone",)),
-    "text": (("text",), ("style",)),
-    "image": ((), ("caption", "alt")),
-    "choices": ((), ("prompt",)),
-    **_PERFORMANCE_KINDS,
-}
-
-
-def _localized_text(value: Any, locale: str) -> str:
-    if isinstance(value, dict):
-        short = (locale or "en").split("-", 1)[0].split("_", 1)[0]
-        for candidate in (short, "en"):
-            if value.get(candidate):
-                return str(value[candidate])
-        return next((str(text) for text in value.values() if text), "")
-    return "" if value is None else str(value)
-
-
-def _variable_index(variables: Sequence[Mapping[str, Any]]) -> dict[str, Mapping[str, Any]]:
-    """The viewer's VISIBLE variables by id. A `hidden` entry (an imported-card MVU leaf a
-    keeper connection receives before `.var expose`) is dropped before any binding
-    resolves — the same rule the reference client applies, so a pack-authored panel
-    cannot surface un-exposed module internals as ordinary panel text on any screen."""
-    return {str(entry.get("id", "")): entry for entry in variables if entry.get("id") and not entry.get("hidden")}
-
-
-def _resolved_scalar(value: Any, index: Mapping[str, Mapping[str, Any]], leaf: Mapping[str, Any] | None) -> Any:
-    """One template scalar with its bindings applied, or `_MISSING` when a binding names
-    a variable this viewer does not have — the fail-closed rule that hides the block."""
-    if isinstance(value, dict) and set(value) == {"$var"}:
-        entry = index.get(str(value["$var"]))
-        return entry["value"] if entry is not None else _MISSING
-    if isinstance(value, dict) and set(value) == {"$leaf"}:
-        # `$leaf` reads the repeat instance's matched variable — its id, label or value,
-        # the three fields the reference client exposes; anything else is a miss.
-        if leaf is None or value["$leaf"] not in ("id", "label", "value"):
-            return _MISSING
-        return leaf.get(str(value["$leaf"]), _MISSING)
-    return value
-
+# :func:`resolve_panel_blocks` is the server-side half of a contract implemented TWICE:
+# it mirrors `clients/tui/src/panelTemplates.ts` `resolvePanelBlocks` — the reference
+# client — rule for rule, turning a panel's template blocks plus ONE viewer's variables
+# into the protocol-v1.7 `ui` blocks that viewer's client would draw. Blocks arrive in
+# WIRE form (`wire_panel` has already resolved every `src` to its content hash), which
+# is exactly what a client receives, so both halves start from the same input.
+#
+# `tests/fixtures/panel_template_vectors.json` IS that agreement: one table, consumed by
+# `tests/core/test_panel_template_vectors.py` and by
+# `clients/tui/src/panelTemplates.vectors.test.ts`, so a rule that moves on either side
+# breaks both suites at once (the shape `visible_when_vectors.json` established for the
+# condition grammar). The reference client is the ORACLE: where the two could differ,
+# this function copies it — including the small oddities noted inline.
+#
+# The text renderer below is then a dumb stringify over resolved blocks. A tier-2
+# panel's `fallback` exists for exactly one purpose — to be READ by a client that cannot
+# render the rich page — and until it existed nothing could turn one into text: a
+# 2026-08-18 play-test found `.panel` produced no frame at all, so a module's
+# look-at-the-chart clues (its whole ◈ layer) were unreachable on a terminal. Sharing
+# the resolver is what keeps the terminal's panel and the rich client's panel from
+# disagreeing about what this viewer may see.
 
 _MISSING = object()
 
+# Per performance kind: (required, optional) RESOLVED text fields — the client's
+# PERFORMANCE_REQUIRED / PERFORMANCE_OPTIONAL. `map_pin`'s hash and x/y are not text and
+# are handled separately, which is why its row differs from `_PERFORMANCE_KINDS` above
+# (that one describes the AUTHORED form, where the map is still a `src` path).
+_PERFORMANCE_TEXT_FIELDS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    "letter": (("body",), ("from", "to", "date")),
+    "clipping": (("headline", "body"), ("source", "date")),
+    "map_pin": (("label",), ("note",)),
+    "title_card": (("title",), ("subtitle", "act")),
+}
 
-def _block_text(block: Mapping[str, Any], index: Mapping[str, Mapping[str, Any]], locale: str, leaf: Mapping[str, Any] | None = None) -> list[str]:
-    """One rendered block as text lines (empty when it is hidden for this viewer)."""
-    condition = block.get("visible_when")
-    if isinstance(condition, str) and condition:
-        def resolve(name: str) -> Any:
-            entry = index.get(name)
-            return entry["value"] if entry is not None else None
 
-        if not evaluate_safe(condition, resolve, default=False):
-            return []
+def _js_text(value: Any) -> str:
+    """``String(value)`` for the scalars the client stringifies into a text field.
 
+    JavaScript has ONE number type and lowercase booleans, so `3.0` prints as ``3`` and
+    `True` prints as ``true``. Python's own ``str`` would answer ``3.0`` and ``True`` —
+    two rows of the shared vector table that would then disagree for no reason at all.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _pick_text(value: Any, locale: str | None) -> str | None:
+    """The client's ``pickPanelText``: this locale, else ``en``, else any non-empty value.
+
+    ``None`` (not ``""``) means "nothing usable here", which is what makes a required
+    field's absence hide its block. A plain string passes through AS IS, empty included —
+    the client's rule, and the one place an empty string is not a miss.
+    """
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, Mapping):
+        return None
+    short = ("en" if locale is None else str(locale))[:2]
+    for candidate in (value.get(short), value.get("en"), *value.values()):
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
+def _localized_text(value: Any, locale: str) -> str:
+    """:func:`_pick_text` for the places that want a plain string (a panel's title)."""
+    return _pick_text(value, locale) or ""
+
+
+def _visible_variables(variables: Sequence[Mapping[str, Any]] | None) -> list[Mapping[str, Any]]:
+    """This viewer's variables minus the ``hidden`` ones, dropped BEFORE anything
+    resolves: a `$var` pointing at one misses and fail-closes its whole block, and
+    `repeat` never instantiates over one. Hidden leaves only reach keeper connections (an
+    imported-card MVU leaf before `.var expose`), so this is not a player-facing leak —
+    but a pack-authored panel must not be able to surface un-exposed module internals as
+    ordinary panel content on any screen."""
+    return [entry for entry in (variables or ()) if not entry.get("hidden")]
+
+
+def _variable_value(variables: Sequence[Mapping[str, Any]], path: str) -> Any:
+    """One condexpr reference: the FIRST visible variable of that id, ``None`` when
+    absent. Nothing else is addressable — `tests/fixtures/visible_when_vectors.json`
+    pins this exact rule for every implementation."""
+    for entry in variables:
+        if entry.get("id") == path:
+            return entry.get("value")
+    return None
+
+
+def _block_visible(block: Mapping[str, Any], variables: Sequence[Mapping[str, Any]]) -> bool:
+    """A block's own ``visible_when`` gate (protocol 2.1) — the value gate `$var`'s
+    absent-means-hide cannot express. Evaluated against the SAME visible variable set
+    every binding sees, so a condition can never widen visibility past the server's wire
+    filter, and an undecidable condition hides its block (fail-closed, like every other
+    miss here). Absent means visible; anything else present — including an empty string —
+    goes through the evaluator, which is the client's `isVisible(condition, …)` exactly."""
+    if "visible_when" not in block:
+        return True
+    return evaluate_safe(block["visible_when"], lambda path: _variable_value(variables, path), default=False)
+
+
+def _resolve_scalar(value: Any, variables: Sequence[Mapping[str, Any]], leaf: Mapping[str, Any] | None) -> Any:
+    """One template scalar with its bindings applied, or :data:`_MISSING` when a binding
+    names something this viewer does not have — the fail-closed rule that hides the block.
+
+    A mapping merely CONTAINING ``$var`` is a binding (the client tests `"$var" in value`,
+    not "is exactly this key"), and ``$var`` wins over ``$leaf`` when both are present.
+    """
+    if isinstance(value, Mapping) and "$var" in value:
+        name = value["$var"]
+        if not isinstance(name, str):
+            return _MISSING
+        for entry in variables:
+            if entry.get("id") == name:
+                return entry.get("value")
+        return _MISSING
+    if isinstance(value, Mapping) and "$leaf" in value:
+        # `$leaf` reads the repeat instance's matched variable — its id, label or value,
+        # the three fields the reference client exposes; anything else is a miss, and so
+        # is any `$leaf` outside a repeat.
+        field = value["$leaf"]
+        if leaf is None or field not in _LEAF_FIELDS:
+            return _MISSING
+        return leaf.get(field)
+    return value
+
+
+def _resolve_text(
+    value: Any, variables: Sequence[Mapping[str, Any]], locale: str | None, leaf: Mapping[str, Any] | None
+) -> str | None:
+    resolved = _resolve_scalar(value, variables, leaf)
+    if resolved is _MISSING:
+        return None
+    if isinstance(resolved, (bool, int, float)):
+        return _js_text(resolved)
+    return _pick_text(resolved, locale)
+
+
+def _finite_number(resolved: Any) -> float | None:
+    """The resolved scalar as a number, or ``None`` — the client's `finiteNumber`. A bool
+    is NOT a number here (Python would call it an int; JavaScript never does)."""
+    if resolved is _MISSING or isinstance(resolved, bool) or not isinstance(resolved, (int, float)):
+        return None
+    return resolved if math.isfinite(resolved) else None
+
+
+def _carry_media_fields(block: Mapping[str, Any], target: dict[str, Any]) -> None:
+    """Copy an image/map_pin's `mime`/`size` through when the wire block carries them.
+
+    The client writes `mime: block.mime` unconditionally, which for an absent field means
+    the key exists holding `undefined` — a key that disappears the moment the object is
+    serialized or compared. An absent key here is that same thing, said in Python.
+    """
+    for field in ("mime", "size"):
+        if field in block:
+            target[field] = block[field]
+
+
+def _resolve_one(
+    block: Mapping[str, Any],
+    variables: Sequence[Mapping[str, Any]],
+    locale: str | None,
+    leaf: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """One template block as the `ui` block a client would draw, or ``None`` when it is
+    hidden/unresolvable for this viewer. Mirrors the client's `resolveOne`."""
     if "repeat" in block:
-        # One instance per visible variable under the prefix, capped at the same count
-        # the reference client expands (filter first, then cap — the cap is on
-        # INSTANCES, never on how far into the variable list a match may sit).
-        spec = block["repeat"]
-        prefix = str(spec.get("prefix", ""))
-        inner = spec.get("block") or {}
-        matches = [entry for entry in index.values() if str(entry.get("id", "")).startswith(prefix)]
-        lines: list[str] = []
-        for entry in matches[:MAX_TEXT_REPEAT_INSTANCES]:
-            lines.extend(_block_text(inner, index, locale, leaf=entry))
-        return lines
+        return None  # expanded by resolve_panel_blocks; nesting resolves to nothing
+    if not _block_visible(block, variables):
+        return None
+    kind = block.get("kind")
 
+    if kind == "divider":
+        return {"kind": "divider"}
+
+    if kind == "meter":
+        label = _resolve_text(block.get("label"), variables, locale, leaf)
+        value = _finite_number(_resolve_scalar(block.get("value"), variables, leaf))
+        low = _finite_number(_resolve_scalar(block.get("min"), variables, leaf))
+        high = _finite_number(_resolve_scalar(block.get("max"), variables, leaf))
+        if label is None or value is None or low is None or high is None or high <= low:
+            return None
+        return {"kind": "meter", "label": label, "value": value, "min": low, "max": high}
+
+    if kind == "stat":
+        label = _resolve_text(block.get("label"), variables, locale, leaf)
+        resolved = _resolve_scalar(block.get("value"), variables, leaf)
+        if label is None or resolved is _MISSING:
+            return None
+        if isinstance(resolved, (bool, int, float)):  # numbers and bools ride as themselves
+            return {"kind": "stat", "label": label, "value": resolved}
+        text = resolved if isinstance(resolved, str) else _pick_text(resolved, locale)
+        return None if text is None else {"kind": "stat", "label": label, "value": text}
+
+    if kind == "badge":
+        label = _resolve_text(block.get("label"), variables, locale, leaf)
+        if label is None:
+            return None
+        badge: dict[str, Any] = {"kind": "badge", "label": label}
+        if "tone" in block:
+            tone = _resolve_scalar(block["tone"], variables, leaf)
+            # v1.7 stance for optional enums: an invalid tone strips, the badge stays.
+            if isinstance(tone, str) and tone in UI_BADGE_TONES:
+                badge["tone"] = tone
+        return badge
+
+    if kind == "text":
+        text = _resolve_text(block.get("text"), variables, locale, leaf)
+        if text is None:
+            return None
+        text_block: dict[str, Any] = {"kind": "text", "text": text}
+        if "style" in block:  # passed through unresolved and unvalidated, as the client does
+            text_block["style"] = block["style"]
+        return text_block
+
+    if kind == "image":
+        # Content-addressed by the pack build — nothing to resolve against state, but a
+        # manifest hand-edited into a hashless block would render as a dead fetch.
+        image_hash = block.get("hash")
+        if not isinstance(image_hash, str) or not image_hash:
+            return None
+        image: dict[str, Any] = {"kind": "image", "hash": image_hash}
+        _carry_media_fields(block, image)
+        caption = _resolve_text(block.get("caption"), variables, locale, leaf)
+        if caption is not None:
+            image["caption"] = caption
+        alt = _resolve_text(block.get("alt"), variables, locale, leaf)
+        if alt is not None:
+            image["alt"] = alt
+        return image
+
+    if kind in _PERFORMANCE_TEXT_FIELDS:
+        # The M19 performance templates: localized text fields, plus `map_pin`'s
+        # content-addressed map and its (bindable) fractional coordinates. Required
+        # fields resolve or the whole block drops, same fail-closed rule as everywhere.
+        required, optional = _PERFORMANCE_TEXT_FIELDS[str(kind)]
+        resolved_block: dict[str, Any] = {"kind": kind}
+        for name in required:
+            text = _resolve_text(block.get(name), variables, locale, leaf)
+            if text is None:
+                return None
+            resolved_block[name] = text
+        for name in optional:
+            text = _resolve_text(block.get(name), variables, locale, leaf)
+            if text is not None:
+                resolved_block[name] = text
+        if kind == "map_pin":
+            x = _finite_number(_resolve_scalar(block.get("x"), variables, leaf))
+            y = _finite_number(_resolve_scalar(block.get("y"), variables, leaf))
+            pin_hash = block.get("hash")
+            if not isinstance(pin_hash, str) or not pin_hash or x is None or y is None:
+                return None
+            resolved_block["hash"] = pin_hash
+            _carry_media_fields(block, resolved_block)
+            # Fractions of the map's own box: a pin outside it is clamped, not dropped.
+            resolved_block["x"] = min(1, max(0, x))
+            resolved_block["y"] = min(1, max(0, y))
+        return resolved_block
+
+    if kind == "choices":
+        options: list[dict[str, Any]] = []
+        for option in block.get("options") or ():
+            if not isinstance(option, Mapping):
+                continue
+            label = _resolve_text(option.get("label"), variables, locale, leaf)
+            if label is None or not isinstance(option.get("input"), str) or not isinstance(option.get("id"), str):
+                continue
+            options.append({"id": option["id"], "label": label, "input": option["input"]})
+        if not options:
+            return None
+        prompt = None if "prompt" not in block else _resolve_text(block["prompt"], variables, locale, leaf)
+        if prompt is None:
+            return {"kind": "choices", "options": options}
+        return {"kind": "choices", "prompt": prompt, "options": options}
+
+    return None
+
+
+def resolve_panel_blocks(
+    blocks: Sequence[Mapping[str, Any]] | None,
+    variables: Sequence[Mapping[str, Any]] | None,
+    locale: str | None = None,
+) -> list[dict[str, Any]]:
+    """Instantiate a panel's WIRE template blocks for ONE viewer.
+
+    `repeat` expands to one instance per VISIBLE variable whose id starts with the prefix
+    (capped at :data:`MAX_REPEAT_INSTANCES`); every unresolved binding drops its whole
+    block (fail-closed), so an empty result is a legitimate outcome — the caller decides
+    what to say about a panel with nothing in it. Mirrors the reference client's
+    `resolvePanelBlocks`; `tests/fixtures/panel_template_vectors.json` is the agreement.
+    """
+    visible = _visible_variables(variables)
+    resolved: list[dict[str, Any]] = []
+    for block in blocks or ():
+        if "repeat" in block:
+            # A repeat may carry its own `visible_when` (the author gating the WHOLE list,
+            # not each instance). `_resolve_one` never sees a repeat, so the gate is
+            # checked here — undecidable hides the whole expansion, as everywhere else.
+            if not _block_visible(block, visible):
+                continue
+            spec = block["repeat"] if isinstance(block["repeat"], Mapping) else {}
+            prefix = spec.get("prefix")
+            inner = spec.get("block")
+            if not isinstance(prefix, str) or not prefix or not isinstance(inner, Mapping) or "repeat" in inner:
+                continue
+            # Filter first, THEN cap: the cap is on instances, never on how far into the
+            # variable list a match may sit (an MVU import puts hundreds ahead of it).
+            matches = [entry for entry in visible if str(entry.get("id", "")).startswith(prefix)]
+            for match in matches[:MAX_REPEAT_INSTANCES]:
+                instance = _resolve_one(inner, visible, locale, match)
+                if instance is not None:
+                    resolved.append(instance)
+            continue
+        instance = _resolve_one(block, visible, locale)
+        if instance is not None:
+            resolved.append(instance)
+    return resolved
+
+
+def _resolved_block_text(block: Mapping[str, Any]) -> list[str]:
+    """One RESOLVED block as text lines. Pure stringify: every binding, every gate and
+    every drop already happened in :func:`resolve_panel_blocks`."""
     kind = block.get("kind")
     if kind == "divider":
         return ["—"]
-
-    # Required fields resolve or the WHOLE block hides; an optional field this viewer
-    # cannot see is simply left out (a `map_pin` without its note, a badge without its
-    # tone) — the reference client's rule for both, so text and rich rendering agree.
-    required, optional = _TEXT_FIELDS.get(str(kind), ((), ()))
-    values: dict[str, Any] = {}
-    for key in (*required, *optional):
-        if key not in block:
-            continue
-        resolved = _resolved_scalar(block[key], index, leaf)
-        if resolved is _MISSING:
-            if key in required:
-                return []
-            continue
-        values[key] = _localized_text(resolved, locale) if key not in ("value", "min", "max") else resolved
-
     if kind == "meter":
-        return [f"{values.get('label', '')}: {values.get('value', '')}/{values.get('max', '')}"]
+        return [f"{block['label']}: {_js_text(block['value'])}/{_js_text(block['max'])}"]
     if kind == "stat":
-        return [f"{values.get('label', '')}: {values.get('value', '')}"]
+        return [f"{block['label']}: {_js_text(block['value'])}"]
     if kind == "badge":
-        return [f"[{values.get('label', '')}]"]
+        return [f"[{block['label']}]"]
     if kind == "text":
-        return [values.get("text", "")]
+        return [str(block["text"])]
     if kind == "image":
-        caption = values.get("caption") or values.get("alt") or ""
-        return [f"🖼 {caption}".rstrip()]
+        return [f"🖼 {block.get('caption') or block.get('alt') or ''}".rstrip()]
     if kind == "choices":
-        # An option whose label binding this viewer cannot see is dropped, and a choices
-        # block with no options left is hidden whole — the reference client's rule.
-        options: list[str] = []
-        for option in block.get("options", []):
-            label = _resolved_scalar(option.get("label"), index, leaf)
-            if label is _MISSING:
-                continue
-            options.append(f"  · {_localized_text(label, locale)} → {option.get('input', '')}")
-        if not options:
-            return []
-        return ([values["prompt"]] if values.get("prompt") else []) + options
+        prompt = [str(block["prompt"])] if block.get("prompt") else []
+        return prompt + [f"  · {option['label']} → {option['input']}" for option in block["options"]]
     if kind == "title_card":
-        head = " · ".join(part for part in (values.get("act"), values.get("title"), values.get("subtitle")) if part)
+        head = " · ".join(part for part in (block.get("act"), block.get("title"), block.get("subtitle")) if part)
         return [f"— {head} —"] if head else []
     if kind == "letter":
-        head = " · ".join(part for part in (values.get("from"), values.get("to"), values.get("date")) if part)
-        return ([f"✉ {head}"] if head else ["✉"]) + [values.get("body", "")]
+        head = " · ".join(part for part in (block.get("from"), block.get("to"), block.get("date")) if part)
+        return ([f"✉ {head}"] if head else ["✉"]) + [str(block.get("body", ""))]
     if kind == "clipping":
-        head = " · ".join(part for part in (values.get("source"), values.get("date")) if part)
-        return [f"📰 {values.get('headline', '')}" + (f" ({head})" if head else ""), values.get("body", "")]
+        head = " · ".join(part for part in (block.get("source"), block.get("date")) if part)
+        return [f"📰 {block.get('headline', '')}" + (f" ({head})" if head else ""), str(block.get("body", ""))]
     if kind == "map_pin":
-        return [f"📍 {values.get('label', '')}" + (f" — {values['note']}" if values.get("note") else "")]
+        return [f"📍 {block.get('label', '')}" + (f" — {block['note']}" if block.get("note") else "")]
     return []
 
 
@@ -664,15 +885,15 @@ def panel_title_text(panel: PanelSpec, locale: str) -> str:
     return _localized_text(panel.title, locale) or panel.id
 
 
-def render_panel_text(panel: PanelSpec, variables: Sequence[Mapping[str, Any]], locale: str) -> list[str]:
-    """`panel` as text lines for THIS viewer: its blocks (tier 1) or its `fallback`
-    (tier 2). Empty when a tier-2 panel declared `fallback: null`, or when every block
-    is hidden — the caller decides what to say about that."""
-    blocks = panel.blocks if panel.tier == 1 else (panel.fallback or ())
-    index = _variable_index(variables)
+def render_panel_text(
+    blocks: Sequence[Mapping[str, Any]] | None, variables: Sequence[Mapping[str, Any]], locale: str
+) -> list[str]:
+    """WIRE panel blocks as text lines for THIS viewer — `wire_panel_blocks` output for a
+    tier-1 panel, or a tier-2 panel's `fallback`. Empty when a tier-2 panel declared
+    `fallback: null`, or when every block is hidden — the caller decides what to say."""
     lines: list[str] = []
-    for block in blocks:
-        lines.extend(_block_text(block, index, locale))
+    for block in resolve_panel_blocks(blocks, variables, locale):
+        lines.extend(_resolved_block_text(block))
     return [line for line in lines if line != ""]
 
 
@@ -718,6 +939,22 @@ def _wire_block(block: Mapping[str, Any], ref: str, asset_info: Mapping[str, Map
     return wired
 
 
+def wire_panel_blocks(
+    pack_id: str, panel: PanelSpec, asset_info: Mapping[str, Mapping[str, Any]]
+) -> list[dict[str, Any]]:
+    """``panel``'s blocks in WIRE form: a tier-1 panel's own blocks, a tier-2 panel's
+    ``fallback`` (empty when it declared ``fallback: null``).
+
+    The blocks half of :func:`wire_panel`, split out so a server-side renderer
+    (`.panel`, via `gateway.panels.panel_wire_blocks`) resolves the SAME
+    content-addressed blocks a client draws instead of hashing anything a second time.
+    Raises ``ValueError`` when an image's integrity record is missing.
+    """
+    ref = f"{pack_id}/{panel.id}"
+    source = panel.blocks if panel.tier == 1 else (panel.fallback or ())
+    return [_wire_block(block, ref, asset_info) for block in source]
+
+
 def wire_panel(pack_id: str, panel: PanelSpec, asset_info: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
     """One ``ui_manifest`` panel entry (protocol v1.8) for ``panel``.
 
@@ -737,7 +974,7 @@ def wire_panel(pack_id: str, panel: PanelSpec, asset_info: Mapping[str, Mapping[
         "tier": panel.tier,
     }
     if panel.tier == 1:
-        entry["blocks"] = [_wire_block(block, ref, asset_info) for block in panel.blocks]
+        entry["blocks"] = wire_panel_blocks(pack_id, panel, asset_info)
         return entry
     entry_info = asset_info.get(panel.entry)
     if entry_info is None:
@@ -759,7 +996,5 @@ def wire_panel(pack_id: str, panel: PanelSpec, asset_info: Mapping[str, Mapping[
             }
         )
     entry["assets"] = assets
-    entry["fallback"] = (
-        None if panel.fallback is None else [_wire_block(block, ref, asset_info) for block in panel.fallback]
-    )
+    entry["fallback"] = None if panel.fallback is None else wire_panel_blocks(pack_id, panel, asset_info)
     return entry

--- a/core/panels.py
+++ b/core/panels.py
@@ -583,6 +583,12 @@ def _pick_text(value: Any, locale: str | None) -> str | None:
     """
     if isinstance(value, str):
         return value
+    if isinstance(value, (list, tuple)):
+        # The client treats ANY non-null object as a locale map and falls through to
+        # `Object.values(...)` — for an array that is its elements in order. Reachable: an
+        # exposed MVU array leaf bound with `$var` lands here, and the rich clients draw
+        # its first string; so must the text fallback.
+        return next((item for item in value if isinstance(item, str) and item), None)
     if not isinstance(value, Mapping):
         return None
     short = ("en" if locale is None else str(locale))[:2]

--- a/docs/notes/implemented/panel-template-vectors.md
+++ b/docs/notes/implemented/panel-template-vectors.md
@@ -8,7 +8,11 @@
   until the next edit: nothing failed when the halves drifted, and three of them already
   had (an empty `visible_when` showed server-side but hid client-side; a duplicate
   variable id resolved to the LAST entry server-side and the first client-side; a
-  `{$var: …, extra: …}` dict was a binding client-side and a literal server-side).
+  `{$var: …, extra: …}` dict was a binding client-side and a literal server-side). The
+  owner's review of the first cut found a fourth, REACHABLE one the subagent had
+  classed as unreachable: an exposed MVU array leaf bound with `$var` — the client
+  treats any object as a locale map and picks the first string element, the engine saw
+  a list, called it "no text" and hid the block. Every one of the four is now a row.
 - **Verdict:** one table, `tests/fixtures/panel_template_vectors.json`, consumed by
   `tests/core/test_panel_template_vectors.py` and
   `clients/tui/src/panelTemplates.vectors.test.ts` — the shape

--- a/docs/notes/implemented/panel-template-vectors.md
+++ b/docs/notes/implemented/panel-template-vectors.md
@@ -9,7 +9,7 @@
   had (an empty `visible_when` showed server-side but hid client-side; a duplicate
   variable id resolved to the LAST entry server-side and the first client-side; a
   `{$var: …, extra: …}` dict was a binding client-side and a literal server-side).
-- **Decision:** one table, `tests/fixtures/panel_template_vectors.json`, consumed by
+- **Verdict:** one table, `tests/fixtures/panel_template_vectors.json`, consumed by
   `tests/core/test_panel_template_vectors.py` and
   `clients/tui/src/panelTemplates.vectors.test.ts` — the shape
   `visible_when_vectors.json` established for the condition grammar. The engine grew a

--- a/docs/notes/implemented/panel-template-vectors.md
+++ b/docs/notes/implemented/panel-template-vectors.md
@@ -1,0 +1,27 @@
+# Implemented: panel template instantiation is a shared vector table
+
+- **Problem:** turning a panel's template blocks plus one viewer's variables into
+  resolved blocks was implemented twice — `clients/tui/src/panelTemplates.ts`
+  (`resolvePanelBlocks`, the reference client) and the server's `.panel` text fallback in
+  `core/panels.py` — and the two were aligned BY HAND on 2026-08-18 (hidden variables,
+  required vs optional fields, repeat filter-then-cap, choices). Hand alignment holds
+  until the next edit: nothing failed when the halves drifted, and three of them already
+  had (an empty `visible_when` showed server-side but hid client-side; a duplicate
+  variable id resolved to the LAST entry server-side and the first client-side; a
+  `{$var: …, extra: …}` dict was a binding client-side and a literal server-side).
+- **Decision:** one table, `tests/fixtures/panel_template_vectors.json`, consumed by
+  `tests/core/test_panel_template_vectors.py` and
+  `clients/tui/src/panelTemplates.vectors.test.ts` — the shape
+  `visible_when_vectors.json` established for the condition grammar. The engine grew a
+  pure `core.panels.resolve_panel_blocks` mirroring the client rule for rule, and
+  `render_panel_text` became a dumb stringify over its output, taking WIRE blocks
+  (`gateway.panels.panel_wire_blocks`) so both halves start from the same input.
+- **Reason:** a panel is instantiated in every client AND on the server, so "they agree"
+  is a promise only a shared fixture can keep — a row that moves breaks both suites at
+  once. The reference client is the ORACLE: where the two could differ, the engine
+  copies it, oddities included (JavaScript's `String()` for numbers and bools, an
+  invalid badge tone stripping rather than dropping, `mime`/`size` written through as
+  `undefined` where the engine simply omits the key).
+- **Rule home:** `core/panels.py` (the "Template instantiation, then text rendering"
+  section); `docs/plugins.md` Layer D.
+- **Date:** 2026-08-19.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -857,6 +857,18 @@ actually shipped as, for anyone reading the code.)*
    (client-evaluated, grammar refused at build outside a tiny portable subset —
    `tests/fixtures/visible_when_vectors.json` is the shared conformance table), and
    content-addressed tier-2 assets with a mandatory text-first `fallback`.
+
+   Template INSTANTIATION — a panel's blocks plus one viewer's variables becoming the
+   blocks that viewer sees — now has a shared table of its own,
+   `tests/fixtures/panel_template_vectors.json`. Every rule lives there as a row: which
+   binding miss drops a whole block and which drops one field, how `repeat` filters
+   before it caps, what an invalid badge tone does, how a `map_pin` clamps its
+   coordinates, which locale wins. The same rows run through the engine
+   (`tests/core/test_panel_template_vectors.py`, over the pure
+   `core.panels.resolve_panel_blocks` the `.panel` text fallback is built on) and through
+   the reference client (`clients/tui/src/panelTemplates.vectors.test.ts`), so a rule that
+   moves on either side breaks both suites. A panel is instantiated per viewer in every
+   client AND on the server; a second client proves itself against this file.
 8. **M16 — rules externalization** — **landed**: the compiled `RuleSystem` + the neutral
    `CheckOutcome`/`Rank` contract; ROLL (engine) → INTERPRET (pack, pure) → APPLY (engine); the
    old per-system modules deleted outright.

--- a/gateway/commands/panels.py
+++ b/gateway/commands/panels.py
@@ -50,7 +50,7 @@ class PanelsCommands:
         knowledge of this command.
         """
         from core.panels import panel_title_text, render_panel_text
-        from gateway.panels import enabled_panels
+        from gateway.panels import enabled_panels, panel_wire_blocks
 
         snapshot = await self._viewer_snapshot(ctx)
         if snapshot:
@@ -85,7 +85,11 @@ class PanelsCommands:
                 ctx.i18n.t("commands.panel.unknown", name=wanted, ids=", ".join(wire_id for wire_id, _ in panels))
             )
         wire_id, panel = matches[0]
-        body = render_panel_text(panel, snapshot.get("variables") or [], ctx.locale)
+        # The WIRE blocks, not the authored ones: `.panel` renders exactly what a client
+        # would draw (`src` paths already resolved to content hashes), through the same
+        # `resolve_panel_blocks` contract the reference client implements.
+        blocks = panel_wire_blocks(ctx.services, wire_id.partition("/")[0], panel)
+        body = render_panel_text(blocks, snapshot.get("variables") or [], ctx.locale)
         title = ctx.i18n.t("commands.panel.title", title=panel_title_text(panel, ctx.locale), id=wire_id)
         if not body:
             return f"{title}\n{ctx.i18n.t('commands.panel.rich_only')}"

--- a/gateway/panels.py
+++ b/gateway/panels.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any
 
 from core.pack import DEV_PACK_HOMES, MANIFEST_NAME, PackManifest, parse_manifest_text
 from core.pack import set_dev_pack_homes as _set_dev_pack_homes
-from core.panels import PanelSpec, audience_allows, parse_panels_text, wire_panel
+from core.panels import PanelSpec, audience_allows, parse_panels_text, wire_panel, wire_panel_blocks
 from gateway.hub import Event, RoomHub
 from gateway.ops import get_enabled_panel_packs
 
@@ -342,6 +342,29 @@ async def build_ui_manifest_frame(services: Services, chat_key: str, role: str) 
             except ValueError:
                 logger.warning("panels: skipping %s/%s (broken integrity records)", pack_id, panel.id, exc_info=True)
     return {"type": "ui_manifest", "panels": panels}
+
+
+def panel_wire_blocks(services: Services, pack_id: str, panel: PanelSpec) -> list[dict[str, Any]]:
+    """ONE panel's blocks in WIRE form — what a client of this room would draw.
+
+    The server-side text fallback (`.panel`, `core.panels.render_panel_text`) needs the
+    same content-addressed blocks the manifest ships, so it goes through the SAME
+    `wire_panel_blocks` + asset-index machinery `build_ui_manifest_frame` uses rather
+    than a second hashing path. Empty when the pack home, its manifest or its integrity
+    records are unreadable (logged) — fail closed, exactly as the manifest path does.
+    """
+    home = installed_pack_homes(services.settings.data_dir).get(pack_id)
+    manifest = _load_manifest(home) if home is not None else None
+    if manifest is None:
+        return []
+    asset_info = {
+        asset.path: {"sha256": asset.sha256, "size": asset.size, "mime": asset.mime} for asset in manifest.assets
+    }
+    try:
+        return wire_panel_blocks(pack_id, panel, asset_info)
+    except ValueError:
+        logger.warning("panels: cannot wire %s/%s (broken integrity records)", pack_id, panel.id, exc_info=True)
+        return []
 
 
 async def enabled_panels(services: Services, chat_key: str, role: str) -> list[tuple[str, PanelSpec]]:

--- a/tests/core/test_panel_template_vectors.py
+++ b/tests/core/test_panel_template_vectors.py
@@ -1,0 +1,83 @@
+"""The Python half of the panel template-instantiation conformance suite.
+
+`tests/fixtures/panel_template_vectors.json` is consumed by BOTH this file and
+`clients/tui/src/panelTemplates.vectors.test.ts`. Turning a panel's template blocks plus
+one viewer's variables into resolved blocks happens in every client AND on the server
+(the `.panel` text fallback), so "the reference client and the engine agree" is a promise
+no amount of prose can keep — the vector table is the promise, and a row that moves
+breaks both suites at once. Same shape as `test_visible_when_vectors.py`, which pinned
+the condition grammar the same way; the reference client stays the oracle.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core.panels import MAX_REPEAT_INSTANCES, resolve_panel_blocks
+
+VECTORS = json.loads(
+    (Path(__file__).resolve().parents[1] / "fixtures" / "panel_template_vectors.json").read_text(encoding="utf-8")
+)
+
+
+def _comparable(value: Any) -> Any:
+    """The shape both halves of the table can be compared in.
+
+    JSON round-trip first, so nothing the resolver happened to build as a tuple compares
+    unequal to the list it becomes on the wire. Then two normalizations that make the
+    comparison say what we MEAN: an integral float is its int (JavaScript has one number
+    type, so the oracle cannot tell `1` from `1.0` and neither should this), and a bool
+    is tagged, because Python's `True == 1` would otherwise let a `stat` that lost its
+    type pass here while failing in the TypeScript half.
+    """
+
+    def walk(node: Any) -> Any:
+        if isinstance(node, bool):
+            return ("bool", node)
+        if isinstance(node, float) and node.is_integer():
+            return int(node)
+        if isinstance(node, dict):
+            return {key: walk(item) for key, item in node.items()}
+        if isinstance(node, list):
+            return [walk(item) for item in node]
+        return node
+
+    return walk(json.loads(json.dumps(value, ensure_ascii=False)))
+
+
+@pytest.mark.parametrize("case", VECTORS["cases"], ids=lambda case: case["id"])
+def test_vector_resolves_as_the_table_says(case: dict) -> None:
+    resolved = resolve_panel_blocks(case["blocks"], case["variables"], case["locale"])
+    assert _comparable(resolved) == _comparable(case["expect"]), case["why"]
+
+
+def test_the_table_covers_the_contract() -> None:
+    # A conformance table that quietly emptied itself would pass every case above.
+    cases = VECTORS["cases"]
+    assert len(cases) >= 30
+    kinds = {
+        block.get("kind")
+        for case in cases
+        for block in case["expect"]
+    }
+    # Every block kind a panel may resolve INTO is exercised by at least one row.
+    assert kinds == {
+        "divider",
+        "meter",
+        "stat",
+        "badge",
+        "text",
+        "image",
+        "choices",
+        "letter",
+        "clipping",
+        "title_card",
+        "map_pin",
+    }
+    # And both halves of fail-closed: rows that render nothing, rows that render a lot.
+    assert any(not case["expect"] for case in cases)
+    assert any(len(case["expect"]) == MAX_REPEAT_INSTANCES for case in cases)

--- a/tests/core/test_panels.py
+++ b/tests/core/test_panels.py
@@ -270,9 +270,10 @@ panels:
 
 # ---------------------------------------------------------------------------
 # Text rendering — `render_panel_text`, the terminal / protocol-client fallback.
-# The oracle is the reference client's `resolvePanelBlocks` semantics: `$var` miss hides
-# the block, `hidden` variables are invisible, repeat expands over VISIBLE matches capped
-# at MAX_REPEAT_INSTANCES, `visible_when` runs through core.condexpr.
+# It stringifies `resolve_panel_blocks` output, whose agreement with the reference
+# client is pinned row by row in `tests/fixtures/panel_template_vectors.json`
+# (`tests/core/test_panel_template_vectors.py` + the TypeScript half). What these tests
+# own is the TEXT: which lines a resolved panel becomes on a terminal.
 # ---------------------------------------------------------------------------
 
 RENDER_YAML = """\
@@ -308,6 +309,14 @@ def _var(id_: str, value, *, label: str | None = None, hidden: bool = False) -> 
     return entry
 
 
+def _wire(panel) -> list[dict]:
+    """The panel's blocks as they ride the wire — what a client actually resolves, and
+    since this batch what `render_panel_text` takes (`src` already a content hash)."""
+    from core.panels import wire_panel_blocks
+
+    return wire_panel_blocks("pack", panel, IMAGE_ASSETS)
+
+
 def test_render_panel_text_binds_hides_and_localizes_like_the_client():
     from core.panels import render_panel_text
 
@@ -319,7 +328,7 @@ def test_render_panel_text_binds_hides_and_localizes_like_the_client():
         _var("clue.1", True, label="A muddy boot"),
         _var("clue.2", True, label="A torn map"),
     ]
-    lines = render_panel_text(panel, variables, "en")
+    lines = render_panel_text(_wire(panel), variables, "en")
     assert lines == [
         "Day: 15",
         "Timber: 8/24",
@@ -341,7 +350,7 @@ def test_render_panel_text_binds_hides_and_localizes_like_the_client():
     # `ghost` never existed for this viewer: the stat bound to it is absent, not blank.
     assert not any("Ghost" in line for line in lines)
 
-    zh = render_panel_text(panel, variables, "zh")
+    zh = render_panel_text(_wire(panel), variables, "zh")
     assert zh[0] == "日: 15" and "  · 走 → I go" in zh and "回家。" in zh
 
 
@@ -357,7 +366,7 @@ def test_render_panel_text_never_reads_a_hidden_variable():
         _var("clue.1", True, label="A muddy boot"),
         _var("gate_open", True),
     ]
-    lines = render_panel_text(panel, variables, "en")
+    lines = render_panel_text(_wire(panel), variables, "en")
     assert "Day: 3" not in lines
     assert "[The murderer]" not in lines and "[A muddy boot]" in lines
     assert "[Open]" in lines
@@ -371,10 +380,10 @@ def test_render_panel_text_repeat_filters_before_it_caps():
     (panel,) = parse_panels_text(RENDER_YAML)
     filler = [_var(f"mvu.node.{index}", index) for index in range(MAX_REPEAT_INSTANCES * 4 + 10)]
     tail = [_var("clue.late", True, label="Found late")]
-    assert "[Found late]" in render_panel_text(panel, filler + tail, "en")
+    assert "[Found late]" in render_panel_text(_wire(panel), filler + tail, "en")
 
     many = [_var(f"clue.{index}", True, label=f"Clue {index}") for index in range(MAX_REPEAT_INSTANCES + 5)]
-    lines = render_panel_text(panel, many, "en")
+    lines = render_panel_text(_wire(panel), many, "en")
     assert sum(1 for line in lines if line.startswith("[Clue ")) == MAX_REPEAT_INSTANCES
 
 
@@ -383,10 +392,10 @@ def test_render_panel_text_uses_the_tier2_fallback_and_reports_none():
 
     (panel,) = parse_panels_text(TIER2_YAML)
     assert panel_title_text(panel, "zh") == "庄园地图"
-    assert render_panel_text(panel, [], "zh") == ["地图请在富客户端查看。"]
-    assert render_panel_text(panel, [], "en") == ["Map in the rich client."]
+    assert render_panel_text(_wire(panel), [], "zh") == ["地图请在富客户端查看。"]
+    assert render_panel_text(_wire(panel), [], "en") == ["Map in the rich client."]
 
     (rich_only,) = parse_panels_text(
         "panels:\n  - {id: p, title: T, slot: modal, entry: ui/p/index.html, assets: [ui/p/index.html], fallback: null}\n"
     )
-    assert render_panel_text(rich_only, [], "en") == []
+    assert render_panel_text(_wire(rich_only), [], "en") == []

--- a/tests/fixtures/panel_template_vectors.json
+++ b/tests/fixtures/panel_template_vectors.json
@@ -1,0 +1,361 @@
+{
+  "_comment": [
+    "GOLDEN VECTORS for panel TEMPLATE INSTANTIATION (M15 tier-1 panels, protocol 2.1).",
+    "",
+    "A panel ships as a TEMPLATE: blocks with `{$var}` / `{$leaf}` bindings, `repeat`",
+    "constructs and `visible_when` gates, instantiated against each viewer's OWN",
+    "`state.variables`. That instantiation happens in every client AND on the server (the",
+    "`.panel` text fallback), so 'the reference client and the engine agree' is a promise",
+    "no amount of prose can keep. This table IS the promise: the same rows run through",
+    "`uv run pytest tests/core/test_panel_template_vectors.py` (`core.panels.",
+    "resolve_panel_blocks`) and through `bun test clients/tui/src/panelTemplates.vectors.",
+    "test.ts` (`resolvePanelBlocks`). A rule that moves on either side breaks both suites.",
+    "",
+    "The reference client is the ORACLE. Where the two could differ, the engine copies it.",
+    "",
+    "Each case: `blocks` (in WIRE form — `wire_panel` has already turned every authored",
+    "`src` path into the `hash`/`mime`/`size` triple, which is what a client receives)",
+    "resolved against `variables` in `locale` must deep-equal `expect`.",
+    "",
+    "The rule under nearly every row is FAIL-CLOSED: a binding this viewer cannot resolve",
+    "omits the WHOLE block, a required field that misses drops the block, an optional one",
+    "drops only itself, and an undecidable `visible_when` hides. A panel can never widen",
+    "visibility — the server's per-viewer state filter stays the single choke point, and",
+    "`hidden` variables are dropped before anything resolves at all.",
+    "",
+    "One representation note: the client writes an image's `mime`/`size` through",
+    "unconditionally, so a wire block without them yields properties holding `undefined` —",
+    "which is what an ABSENT key is once the object is serialized or compared. The engine",
+    "omits them instead; `image-without-mime-or-size` is that agreement, written down."
+  ],
+  "cases": [
+    {
+      "id": "divider",
+      "why": "nothing to resolve, nothing to hide: a divider always survives",
+      "blocks": [{"kind": "divider"}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "divider"}]
+    },
+    {
+      "id": "meter-binds-and-localizes",
+      "why": "the ordinary bound gauge: value from this viewer's variable, label in this locale",
+      "blocks": [{"kind": "meter", "label": {"en": "Fear", "zh": "恐慌"}, "value": {"$var": "town_fear"}, "min": 0, "max": 10}],
+      "variables": [{"id": "town_fear", "label": "Fear", "value": 7}],
+      "locale": "zh",
+      "expect": [{"kind": "meter", "label": "恐慌", "value": 7, "min": 0, "max": 10}]
+    },
+    {
+      "id": "meter-var-miss-drops-only-its-own-block",
+      "why": "fail-closed is per block, not per panel — the neighbours still render",
+      "blocks": [{"kind": "meter", "label": {"en": "Doom"}, "value": {"$var": "keeper_secret"}, "min": 0, "max": 10}, {"kind": "text", "text": {"en": "still here"}}],
+      "variables": [{"id": "town_fear", "label": "Fear", "value": 7}],
+      "locale": "en",
+      "expect": [{"kind": "text", "text": "still here"}]
+    },
+    {
+      "id": "meter-max-not-greater-than-min",
+      "why": "a zero-width gauge cannot be drawn, so it is not sent",
+      "blocks": [{"kind": "meter", "label": {"en": "Fear"}, "value": 10, "min": 10, "max": 10}],
+      "variables": [],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "meter-value-that-is-not-a-number",
+      "why": "a gauge bound to a text variable resolves to nothing, never to a guess",
+      "blocks": [{"kind": "meter", "label": {"en": "Fear"}, "value": {"$var": "note"}, "min": 0, "max": 10}],
+      "variables": [{"id": "note", "label": "note", "value": "seven"}],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "stat-passes-numbers-bools-and-strings-through",
+      "why": "a stat's value keeps its TYPE: 7 is not '7' and true is not 'true'",
+      "blocks": [{"kind": "stat", "label": {"en": "Day"}, "value": {"$var": "day"}}, {"kind": "stat", "label": {"en": "Alerted"}, "value": {"$var": "alerted"}}, {"kind": "stat", "label": {"en": "Note"}, "value": {"$var": "note"}}],
+      "variables": [{"id": "day", "label": "day", "value": 15}, {"id": "alerted", "label": "alerted", "value": true}, {"id": "note", "label": "note", "value": "cold ash"}],
+      "locale": "en",
+      "expect": [{"kind": "stat", "label": "Day", "value": 15}, {"kind": "stat", "label": "Alerted", "value": true}, {"kind": "stat", "label": "Note", "value": "cold ash"}]
+    },
+    {
+      "id": "stat-value-may-be-a-localized-map",
+      "why": "an authored value is localized text like any other field",
+      "blocks": [{"kind": "stat", "label": {"en": "Gate", "zh": "门"}, "value": {"en": "Open", "zh": "已开"}}],
+      "variables": [],
+      "locale": "zh",
+      "expect": [{"kind": "stat", "label": "门", "value": "已开"}]
+    },
+    {
+      "id": "stat-label-miss-drops-the-block",
+      "why": "a label is required — a stat with a value and no name says nothing",
+      "blocks": [{"kind": "stat", "label": {"$var": "keeper_secret"}, "value": 15}],
+      "variables": [{"id": "day", "label": "day", "value": 15}],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "badge-carries-a-valid-tone",
+      "why": "the happy path for the optional enum",
+      "blocks": [{"kind": "badge", "label": {"en": "Alerted"}, "tone": "warn"}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "badge", "label": "Alerted", "tone": "warn"}]
+    },
+    {
+      "id": "badge-invalid-tone-strips-the-tone-not-the-badge",
+      "why": "v1.7 stance for optional enums: drop the field, keep the block",
+      "blocks": [{"kind": "badge", "label": {"en": "Alerted"}, "tone": "scarlet"}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "badge", "label": "Alerted"}]
+    },
+    {
+      "id": "text-style-passes-through-when-present",
+      "why": "`style` is authored, not bound — it rides along untouched",
+      "blocks": [{"kind": "text", "text": {"en": "He never came back."}, "style": "quote"}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "text", "text": "He never came back.", "style": "quote"}]
+    },
+    {
+      "id": "text-stringifies-numbers-and-booleans",
+      "why": "JavaScript's String(): one number type (3.0 prints as 3) and lowercase booleans",
+      "blocks": [{"kind": "text", "text": {"$var": "day"}}, {"kind": "text", "text": {"$var": "alerted"}}],
+      "variables": [{"id": "day", "label": "day", "value": 3}, {"id": "alerted", "label": "alerted", "value": true}],
+      "locale": "en",
+      "expect": [{"kind": "text", "text": "3"}, {"kind": "text", "text": "true"}]
+    },
+    {
+      "id": "image-happy-path",
+      "why": "content-addressed by the pack build; caption and alt are ordinary localized text",
+      "blocks": [{"kind": "image", "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "mime": "image/png", "size": 4096, "caption": {"en": "The gate", "zh": "门"}, "alt": {"en": "A gate in the rain"}}],
+      "variables": [],
+      "locale": "zh",
+      "expect": [{"kind": "image", "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "mime": "image/png", "size": 4096, "caption": "门", "alt": "A gate in the rain"}]
+    },
+    {
+      "id": "image-without-a-hash-is-dropped",
+      "why": "a manifest hand-edited into a hashless block would render as a dead fetch",
+      "blocks": [{"kind": "image", "mime": "image/png", "size": 4096}],
+      "variables": [],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "image-caption-miss-drops-the-caption",
+      "why": "caption/alt are optional: the picture still ships",
+      "blocks": [{"kind": "image", "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "mime": "image/png", "size": 4096, "caption": {"$var": "keeper_secret"}}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "image", "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "mime": "image/png", "size": 4096}]
+    },
+    {
+      "id": "image-without-mime-or-size",
+      "why": "the one representation agreement: the client's `undefined` property is an absent key",
+      "blocks": [{"kind": "image", "hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "image", "hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]
+    },
+    {
+      "id": "choices-happy-path",
+      "why": "prompt plus options, each with the input string it sends back verbatim",
+      "blocks": [{"kind": "choices", "prompt": {"en": "Now?", "zh": "现在？"}, "options": [{"id": "go", "label": {"en": "Go", "zh": "走"}, "input": "I go"}, {"id": "wait", "label": {"en": "Wait"}, "input": "I wait"}]}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "choices", "prompt": "Now?", "options": [{"id": "go", "label": "Go", "input": "I go"}, {"id": "wait", "label": "Wait", "input": "I wait"}]}]
+    },
+    {
+      "id": "choices-drops-an-unusable-option-not-the-block",
+      "why": "a label this viewer cannot see, or a non-string id/input, takes that option only",
+      "blocks": [{"kind": "choices", "options": [{"id": "secret", "label": {"$var": "keeper_secret"}, "input": "I know"}, {"id": "typo", "label": {"en": "Wait"}, "input": 3}, {"id": 7, "label": {"en": "Run"}, "input": "I run"}, {"id": "go", "label": {"en": "Go"}, "input": "I go"}]}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "choices", "options": [{"id": "go", "label": "Go", "input": "I go"}]}]
+    },
+    {
+      "id": "choices-with-no-usable-option-is-dropped",
+      "why": "an empty chooser is worse than no chooser",
+      "blocks": [{"kind": "choices", "prompt": {"en": "Now?"}, "options": [{"id": "a", "label": {"$var": "keeper_secret"}, "input": "x"}]}],
+      "variables": [],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "choices-prompt-is-optional",
+      "why": "no prompt authored, no prompt on the wire",
+      "blocks": [{"kind": "choices", "options": [{"id": "go", "label": {"en": "Go"}, "input": "I go"}]}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "choices", "options": [{"id": "go", "label": "Go", "input": "I go"}]}]
+    },
+    {
+      "id": "performance-kinds-happy-path",
+      "why": "all four M19 templates with every field authored",
+      "blocks": [{"kind": "letter", "body": {"en": "Come home."}, "from": {"en": "Ma"}, "to": {"en": "Da"}, "date": {"en": "1926"}}, {"kind": "clipping", "headline": {"en": "Flood"}, "body": {"en": "Rain."}, "source": {"en": "Gazette"}, "date": {"en": "1926"}}, {"kind": "title_card", "title": {"en": "Landing"}, "subtitle": {"en": "a wet dawn"}, "act": {"en": "Act I"}}, {"kind": "map_pin", "hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "mime": "image/webp", "size": 2048, "label": {"en": "The well"}, "x": 0.2, "y": 0.4, "note": {"en": "still wet"}}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "letter", "body": "Come home.", "from": "Ma", "to": "Da", "date": "1926"}, {"kind": "clipping", "headline": "Flood", "body": "Rain.", "source": "Gazette", "date": "1926"}, {"kind": "title_card", "title": "Landing", "subtitle": "a wet dawn", "act": "Act I"}, {"kind": "map_pin", "label": "The well", "note": "still wet", "hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "mime": "image/webp", "size": 2048, "x": 0.2, "y": 0.4}]
+    },
+    {
+      "id": "performance-optional-field-miss-drops-the-field",
+      "why": "one missing optional per kind: the block still performs, one line shorter",
+      "blocks": [{"kind": "letter", "body": {"en": "Come home."}, "from": {"$var": "keeper_secret"}}, {"kind": "clipping", "headline": {"en": "Flood"}, "body": {"en": "Rain."}, "source": {"$var": "keeper_secret"}}, {"kind": "title_card", "title": {"en": "Landing"}, "subtitle": {"$var": "keeper_secret"}}, {"kind": "map_pin", "hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "mime": "image/webp", "size": 2048, "label": {"en": "The well"}, "x": 0.2, "y": 0.4, "note": {"$var": "keeper_secret"}}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "letter", "body": "Come home."}, {"kind": "clipping", "headline": "Flood", "body": "Rain."}, {"kind": "title_card", "title": "Landing"}, {"kind": "map_pin", "label": "The well", "hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "mime": "image/webp", "size": 2048, "x": 0.2, "y": 0.4}]
+    },
+    {
+      "id": "performance-required-field-miss-drops-the-block",
+      "why": "one missing required per kind: a letter with no body is not a letter",
+      "blocks": [{"kind": "letter", "body": {"$var": "keeper_secret"}, "from": {"en": "Ma"}}, {"kind": "clipping", "headline": {"$var": "keeper_secret"}, "body": {"en": "Rain."}}, {"kind": "title_card", "title": {"$var": "keeper_secret"}, "act": {"en": "Act I"}}, {"kind": "map_pin", "hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "mime": "image/webp", "size": 2048, "label": {"$var": "keeper_secret"}, "x": 0.2, "y": 0.4}],
+      "variables": [],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "map-pin-clamps-its-coordinates",
+      "why": "x/y are fractions of the map's own box: a pin outside it is clamped, not dropped",
+      "blocks": [{"kind": "map_pin", "hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "mime": "image/webp", "size": 2048, "label": {"en": "The well"}, "x": 1.4, "y": -0.3}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "map_pin", "label": "The well", "hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "mime": "image/webp", "size": 2048, "x": 1, "y": 0}]
+    },
+    {
+      "id": "map-pin-without-a-coordinate-is-dropped",
+      "why": "a pin with nowhere to sit is not a pin",
+      "blocks": [{"kind": "map_pin", "hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "mime": "image/webp", "size": 2048, "label": {"en": "The well"}, "y": 0.4}],
+      "variables": [],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "hidden-variable-is-absent-to-a-binding",
+      "why": "an un-exposed MVU leaf reaches keeper connections flagged hidden; a panel still cannot read it",
+      "blocks": [{"kind": "stat", "label": {"en": "Day"}, "value": {"$var": "day"}}, {"kind": "text", "text": {"en": "still here"}}],
+      "variables": [{"id": "day", "label": "day", "value": 15, "hidden": true}],
+      "locale": "en",
+      "expect": [{"kind": "text", "text": "still here"}]
+    },
+    {
+      "id": "hidden-variable-is-never-a-repeat-instance",
+      "why": "the same rule from the other side: hidden leaves are filtered before the prefix match",
+      "blocks": [{"repeat": {"prefix": "clue.", "block": {"kind": "badge", "label": {"$leaf": "label"}}}}],
+      "variables": [{"id": "clue.boot", "label": "A muddy boot", "value": true}, {"id": "clue.name", "label": "The murderer", "value": true, "hidden": true}],
+      "locale": "en",
+      "expect": [{"kind": "badge", "label": "A muddy boot"}]
+    },
+    {
+      "id": "repeat-substitutes-leaf-id-label-and-value",
+      "why": "the three fields `$leaf` exposes, over the same matched variables",
+      "blocks": [{"repeat": {"prefix": "clue.", "block": {"kind": "stat", "label": {"$leaf": "label"}, "value": {"$leaf": "value"}}}}, {"repeat": {"prefix": "clue.", "block": {"kind": "text", "text": {"$leaf": "id"}}}}],
+      "variables": [{"id": "clue.ash", "label": "cold ash", "value": "a smear"}, {"id": "clue.ring", "label": "a brass ring", "value": true}],
+      "locale": "en",
+      "expect": [{"kind": "stat", "label": "cold ash", "value": "a smear"}, {"kind": "stat", "label": "a brass ring", "value": true}, {"kind": "text", "text": "clue.ash"}, {"kind": "text", "text": "clue.ring"}]
+    },
+    {
+      "id": "leaf-field-outside-id-label-value-is-a-miss",
+      "why": "the binding vocabulary is closed; an unknown field hides its block rather than guessing",
+      "blocks": [{"repeat": {"prefix": "clue.", "block": {"kind": "badge", "label": {"$leaf": "kind"}}}}],
+      "variables": [{"id": "clue.ash", "label": "cold ash", "value": true}],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "leaf-outside-a-repeat-is-a-miss",
+      "why": "there is no matched variable to read, so there is nothing to render",
+      "blocks": [{"kind": "badge", "label": {"$leaf": "label"}}],
+      "variables": [{"id": "clue.ash", "label": "cold ash", "value": true}],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "repeat-caps-its-instances",
+      "why": "MAX_PANEL_REPEAT_INSTANCES is 32: 35 matches expand to exactly 32, in order",
+      "blocks": [{"repeat": {"prefix": "clue.", "block": {"kind": "badge", "label": {"$leaf": "label"}}}}],
+      "variables": [{"id": "clue.00", "label": "Clue 00", "value": true}, {"id": "clue.01", "label": "Clue 01", "value": true}, {"id": "clue.02", "label": "Clue 02", "value": true}, {"id": "clue.03", "label": "Clue 03", "value": true}, {"id": "clue.04", "label": "Clue 04", "value": true}, {"id": "clue.05", "label": "Clue 05", "value": true}, {"id": "clue.06", "label": "Clue 06", "value": true}, {"id": "clue.07", "label": "Clue 07", "value": true}, {"id": "clue.08", "label": "Clue 08", "value": true}, {"id": "clue.09", "label": "Clue 09", "value": true}, {"id": "clue.10", "label": "Clue 10", "value": true}, {"id": "clue.11", "label": "Clue 11", "value": true}, {"id": "clue.12", "label": "Clue 12", "value": true}, {"id": "clue.13", "label": "Clue 13", "value": true}, {"id": "clue.14", "label": "Clue 14", "value": true}, {"id": "clue.15", "label": "Clue 15", "value": true}, {"id": "clue.16", "label": "Clue 16", "value": true}, {"id": "clue.17", "label": "Clue 17", "value": true}, {"id": "clue.18", "label": "Clue 18", "value": true}, {"id": "clue.19", "label": "Clue 19", "value": true}, {"id": "clue.20", "label": "Clue 20", "value": true}, {"id": "clue.21", "label": "Clue 21", "value": true}, {"id": "clue.22", "label": "Clue 22", "value": true}, {"id": "clue.23", "label": "Clue 23", "value": true}, {"id": "clue.24", "label": "Clue 24", "value": true}, {"id": "clue.25", "label": "Clue 25", "value": true}, {"id": "clue.26", "label": "Clue 26", "value": true}, {"id": "clue.27", "label": "Clue 27", "value": true}, {"id": "clue.28", "label": "Clue 28", "value": true}, {"id": "clue.29", "label": "Clue 29", "value": true}, {"id": "clue.30", "label": "Clue 30", "value": true}, {"id": "clue.31", "label": "Clue 31", "value": true}, {"id": "clue.32", "label": "Clue 32", "value": true}, {"id": "clue.33", "label": "Clue 33", "value": true}, {"id": "clue.34", "label": "Clue 34", "value": true}],
+      "locale": "en",
+      "expect": [{"kind": "badge", "label": "Clue 00"}, {"kind": "badge", "label": "Clue 01"}, {"kind": "badge", "label": "Clue 02"}, {"kind": "badge", "label": "Clue 03"}, {"kind": "badge", "label": "Clue 04"}, {"kind": "badge", "label": "Clue 05"}, {"kind": "badge", "label": "Clue 06"}, {"kind": "badge", "label": "Clue 07"}, {"kind": "badge", "label": "Clue 08"}, {"kind": "badge", "label": "Clue 09"}, {"kind": "badge", "label": "Clue 10"}, {"kind": "badge", "label": "Clue 11"}, {"kind": "badge", "label": "Clue 12"}, {"kind": "badge", "label": "Clue 13"}, {"kind": "badge", "label": "Clue 14"}, {"kind": "badge", "label": "Clue 15"}, {"kind": "badge", "label": "Clue 16"}, {"kind": "badge", "label": "Clue 17"}, {"kind": "badge", "label": "Clue 18"}, {"kind": "badge", "label": "Clue 19"}, {"kind": "badge", "label": "Clue 20"}, {"kind": "badge", "label": "Clue 21"}, {"kind": "badge", "label": "Clue 22"}, {"kind": "badge", "label": "Clue 23"}, {"kind": "badge", "label": "Clue 24"}, {"kind": "badge", "label": "Clue 25"}, {"kind": "badge", "label": "Clue 26"}, {"kind": "badge", "label": "Clue 27"}, {"kind": "badge", "label": "Clue 28"}, {"kind": "badge", "label": "Clue 29"}, {"kind": "badge", "label": "Clue 30"}, {"kind": "badge", "label": "Clue 31"}]
+    },
+    {
+      "id": "repeat-filters-before-it-caps",
+      "why": "the cap is on INSTANCES, never on how deep into an MVU import a match may sit",
+      "blocks": [{"repeat": {"prefix": "clue.", "block": {"kind": "badge", "label": {"$leaf": "label"}}}}],
+      "variables": [{"id": "mvu.node.0", "label": "mvu.node.0", "value": 0}, {"id": "mvu.node.1", "label": "mvu.node.1", "value": 1}, {"id": "mvu.node.2", "label": "mvu.node.2", "value": 2}, {"id": "mvu.node.3", "label": "mvu.node.3", "value": 3}, {"id": "mvu.node.4", "label": "mvu.node.4", "value": 4}, {"id": "mvu.node.5", "label": "mvu.node.5", "value": 5}, {"id": "mvu.node.6", "label": "mvu.node.6", "value": 6}, {"id": "mvu.node.7", "label": "mvu.node.7", "value": 7}, {"id": "mvu.node.8", "label": "mvu.node.8", "value": 8}, {"id": "mvu.node.9", "label": "mvu.node.9", "value": 9}, {"id": "mvu.node.10", "label": "mvu.node.10", "value": 10}, {"id": "mvu.node.11", "label": "mvu.node.11", "value": 11}, {"id": "mvu.node.12", "label": "mvu.node.12", "value": 12}, {"id": "mvu.node.13", "label": "mvu.node.13", "value": 13}, {"id": "mvu.node.14", "label": "mvu.node.14", "value": 14}, {"id": "mvu.node.15", "label": "mvu.node.15", "value": 15}, {"id": "mvu.node.16", "label": "mvu.node.16", "value": 16}, {"id": "mvu.node.17", "label": "mvu.node.17", "value": 17}, {"id": "mvu.node.18", "label": "mvu.node.18", "value": 18}, {"id": "mvu.node.19", "label": "mvu.node.19", "value": 19}, {"id": "mvu.node.20", "label": "mvu.node.20", "value": 20}, {"id": "mvu.node.21", "label": "mvu.node.21", "value": 21}, {"id": "mvu.node.22", "label": "mvu.node.22", "value": 22}, {"id": "mvu.node.23", "label": "mvu.node.23", "value": 23}, {"id": "mvu.node.24", "label": "mvu.node.24", "value": 24}, {"id": "mvu.node.25", "label": "mvu.node.25", "value": 25}, {"id": "mvu.node.26", "label": "mvu.node.26", "value": 26}, {"id": "mvu.node.27", "label": "mvu.node.27", "value": 27}, {"id": "mvu.node.28", "label": "mvu.node.28", "value": 28}, {"id": "mvu.node.29", "label": "mvu.node.29", "value": 29}, {"id": "mvu.node.30", "label": "mvu.node.30", "value": 30}, {"id": "mvu.node.31", "label": "mvu.node.31", "value": 31}, {"id": "mvu.node.32", "label": "mvu.node.32", "value": 32}, {"id": "mvu.node.33", "label": "mvu.node.33", "value": 33}, {"id": "mvu.node.34", "label": "mvu.node.34", "value": 34}, {"id": "mvu.node.35", "label": "mvu.node.35", "value": 35}, {"id": "mvu.node.36", "label": "mvu.node.36", "value": 36}, {"id": "mvu.node.37", "label": "mvu.node.37", "value": 37}, {"id": "mvu.node.38", "label": "mvu.node.38", "value": 38}, {"id": "mvu.node.39", "label": "mvu.node.39", "value": 39}, {"id": "mvu.node.40", "label": "mvu.node.40", "value": 40}, {"id": "mvu.node.41", "label": "mvu.node.41", "value": 41}, {"id": "mvu.node.42", "label": "mvu.node.42", "value": 42}, {"id": "mvu.node.43", "label": "mvu.node.43", "value": 43}, {"id": "mvu.node.44", "label": "mvu.node.44", "value": 44}, {"id": "mvu.node.45", "label": "mvu.node.45", "value": 45}, {"id": "mvu.node.46", "label": "mvu.node.46", "value": 46}, {"id": "mvu.node.47", "label": "mvu.node.47", "value": 47}, {"id": "mvu.node.48", "label": "mvu.node.48", "value": 48}, {"id": "mvu.node.49", "label": "mvu.node.49", "value": 49}, {"id": "mvu.node.50", "label": "mvu.node.50", "value": 50}, {"id": "mvu.node.51", "label": "mvu.node.51", "value": 51}, {"id": "mvu.node.52", "label": "mvu.node.52", "value": 52}, {"id": "mvu.node.53", "label": "mvu.node.53", "value": 53}, {"id": "mvu.node.54", "label": "mvu.node.54", "value": 54}, {"id": "mvu.node.55", "label": "mvu.node.55", "value": 55}, {"id": "mvu.node.56", "label": "mvu.node.56", "value": 56}, {"id": "mvu.node.57", "label": "mvu.node.57", "value": 57}, {"id": "mvu.node.58", "label": "mvu.node.58", "value": 58}, {"id": "mvu.node.59", "label": "mvu.node.59", "value": 59}, {"id": "mvu.node.60", "label": "mvu.node.60", "value": 60}, {"id": "mvu.node.61", "label": "mvu.node.61", "value": 61}, {"id": "mvu.node.62", "label": "mvu.node.62", "value": 62}, {"id": "mvu.node.63", "label": "mvu.node.63", "value": 63}, {"id": "mvu.node.64", "label": "mvu.node.64", "value": 64}, {"id": "mvu.node.65", "label": "mvu.node.65", "value": 65}, {"id": "mvu.node.66", "label": "mvu.node.66", "value": 66}, {"id": "mvu.node.67", "label": "mvu.node.67", "value": 67}, {"id": "mvu.node.68", "label": "mvu.node.68", "value": 68}, {"id": "mvu.node.69", "label": "mvu.node.69", "value": 69}, {"id": "mvu.node.70", "label": "mvu.node.70", "value": 70}, {"id": "mvu.node.71", "label": "mvu.node.71", "value": 71}, {"id": "mvu.node.72", "label": "mvu.node.72", "value": 72}, {"id": "mvu.node.73", "label": "mvu.node.73", "value": 73}, {"id": "mvu.node.74", "label": "mvu.node.74", "value": 74}, {"id": "mvu.node.75", "label": "mvu.node.75", "value": 75}, {"id": "mvu.node.76", "label": "mvu.node.76", "value": 76}, {"id": "mvu.node.77", "label": "mvu.node.77", "value": 77}, {"id": "mvu.node.78", "label": "mvu.node.78", "value": 78}, {"id": "mvu.node.79", "label": "mvu.node.79", "value": 79}, {"id": "mvu.node.80", "label": "mvu.node.80", "value": 80}, {"id": "mvu.node.81", "label": "mvu.node.81", "value": 81}, {"id": "mvu.node.82", "label": "mvu.node.82", "value": 82}, {"id": "mvu.node.83", "label": "mvu.node.83", "value": 83}, {"id": "mvu.node.84", "label": "mvu.node.84", "value": 84}, {"id": "mvu.node.85", "label": "mvu.node.85", "value": 85}, {"id": "mvu.node.86", "label": "mvu.node.86", "value": 86}, {"id": "mvu.node.87", "label": "mvu.node.87", "value": 87}, {"id": "mvu.node.88", "label": "mvu.node.88", "value": 88}, {"id": "mvu.node.89", "label": "mvu.node.89", "value": 89}, {"id": "mvu.node.90", "label": "mvu.node.90", "value": 90}, {"id": "mvu.node.91", "label": "mvu.node.91", "value": 91}, {"id": "mvu.node.92", "label": "mvu.node.92", "value": 92}, {"id": "mvu.node.93", "label": "mvu.node.93", "value": 93}, {"id": "mvu.node.94", "label": "mvu.node.94", "value": 94}, {"id": "mvu.node.95", "label": "mvu.node.95", "value": 95}, {"id": "mvu.node.96", "label": "mvu.node.96", "value": 96}, {"id": "mvu.node.97", "label": "mvu.node.97", "value": 97}, {"id": "mvu.node.98", "label": "mvu.node.98", "value": 98}, {"id": "mvu.node.99", "label": "mvu.node.99", "value": 99}, {"id": "mvu.node.100", "label": "mvu.node.100", "value": 100}, {"id": "mvu.node.101", "label": "mvu.node.101", "value": 101}, {"id": "mvu.node.102", "label": "mvu.node.102", "value": 102}, {"id": "mvu.node.103", "label": "mvu.node.103", "value": 103}, {"id": "mvu.node.104", "label": "mvu.node.104", "value": 104}, {"id": "mvu.node.105", "label": "mvu.node.105", "value": 105}, {"id": "mvu.node.106", "label": "mvu.node.106", "value": 106}, {"id": "mvu.node.107", "label": "mvu.node.107", "value": 107}, {"id": "mvu.node.108", "label": "mvu.node.108", "value": 108}, {"id": "mvu.node.109", "label": "mvu.node.109", "value": 109}, {"id": "mvu.node.110", "label": "mvu.node.110", "value": 110}, {"id": "mvu.node.111", "label": "mvu.node.111", "value": 111}, {"id": "mvu.node.112", "label": "mvu.node.112", "value": 112}, {"id": "mvu.node.113", "label": "mvu.node.113", "value": 113}, {"id": "mvu.node.114", "label": "mvu.node.114", "value": 114}, {"id": "mvu.node.115", "label": "mvu.node.115", "value": 115}, {"id": "mvu.node.116", "label": "mvu.node.116", "value": 116}, {"id": "mvu.node.117", "label": "mvu.node.117", "value": 117}, {"id": "mvu.node.118", "label": "mvu.node.118", "value": 118}, {"id": "mvu.node.119", "label": "mvu.node.119", "value": 119}, {"id": "mvu.node.120", "label": "mvu.node.120", "value": 120}, {"id": "mvu.node.121", "label": "mvu.node.121", "value": 121}, {"id": "mvu.node.122", "label": "mvu.node.122", "value": 122}, {"id": "mvu.node.123", "label": "mvu.node.123", "value": 123}, {"id": "mvu.node.124", "label": "mvu.node.124", "value": 124}, {"id": "mvu.node.125", "label": "mvu.node.125", "value": 125}, {"id": "mvu.node.126", "label": "mvu.node.126", "value": 126}, {"id": "mvu.node.127", "label": "mvu.node.127", "value": 127}, {"id": "mvu.node.128", "label": "mvu.node.128", "value": 128}, {"id": "mvu.node.129", "label": "mvu.node.129", "value": 129}, {"id": "mvu.node.130", "label": "mvu.node.130", "value": 130}, {"id": "mvu.node.131", "label": "mvu.node.131", "value": 131}, {"id": "mvu.node.132", "label": "mvu.node.132", "value": 132}, {"id": "mvu.node.133", "label": "mvu.node.133", "value": 133}, {"id": "mvu.node.134", "label": "mvu.node.134", "value": 134}, {"id": "mvu.node.135", "label": "mvu.node.135", "value": 135}, {"id": "mvu.node.136", "label": "mvu.node.136", "value": 136}, {"id": "mvu.node.137", "label": "mvu.node.137", "value": 137}, {"id": "mvu.node.138", "label": "mvu.node.138", "value": 138}, {"id": "mvu.node.139", "label": "mvu.node.139", "value": 139}, {"id": "mvu.node.140", "label": "mvu.node.140", "value": 140}, {"id": "mvu.node.141", "label": "mvu.node.141", "value": 141}, {"id": "mvu.node.142", "label": "mvu.node.142", "value": 142}, {"id": "mvu.node.143", "label": "mvu.node.143", "value": 143}, {"id": "mvu.node.144", "label": "mvu.node.144", "value": 144}, {"id": "mvu.node.145", "label": "mvu.node.145", "value": 145}, {"id": "mvu.node.146", "label": "mvu.node.146", "value": 146}, {"id": "mvu.node.147", "label": "mvu.node.147", "value": 147}, {"id": "mvu.node.148", "label": "mvu.node.148", "value": 148}, {"id": "mvu.node.149", "label": "mvu.node.149", "value": 149}, {"id": "clue.late", "label": "Found late", "value": true}],
+      "locale": "en",
+      "expect": [{"kind": "badge", "label": "Found late"}]
+    },
+    {
+      "id": "repeat-does-not-nest",
+      "why": "a repeat inside a repeat resolves to nothing at all — the schema refuses it at build too",
+      "blocks": [{"repeat": {"prefix": "clue.", "block": {"repeat": {"prefix": "clue.", "block": {"kind": "divider"}}}}}],
+      "variables": [{"id": "clue.ash", "label": "cold ash", "value": true}],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "repeat-carries-its-own-visible-when",
+      "why": "the author gating the WHOLE list: false hides every instance, not one of them",
+      "blocks": [{"repeat": {"prefix": "clue.", "block": {"kind": "badge", "label": {"$leaf": "label"}}}, "visible_when": "board_open"}, {"kind": "text", "text": {"en": "still here"}}],
+      "variables": [{"id": "board_open", "label": "board_open", "value": false}, {"id": "clue.ash", "label": "cold ash", "value": true}],
+      "locale": "en",
+      "expect": [{"kind": "text", "text": "still here"}]
+    },
+    {
+      "id": "repeat-without-a-usable-prefix",
+      "why": "a missing or empty prefix would match EVERY variable; it expands to nothing instead",
+      "blocks": [{"repeat": {"block": {"kind": "badge", "label": {"$leaf": "label"}}}}, {"repeat": {"prefix": "", "block": {"kind": "badge", "label": {"$leaf": "label"}}}}],
+      "variables": [{"id": "clue.ash", "label": "cold ash", "value": true}],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "visible-when-decides-per-block",
+      "why": "the value gate `$var`'s absent-means-hide cannot express",
+      "blocks": [{"kind": "badge", "label": {"en": "Open"}, "visible_when": "gate_open"}, {"kind": "badge", "label": {"en": "Shut"}, "visible_when": "!gate_open"}],
+      "variables": [{"id": "gate_open", "label": "gate_open", "value": false}],
+      "locale": "en",
+      "expect": [{"kind": "badge", "label": "Shut"}]
+    },
+    {
+      "id": "visible-when-undecidable-hides",
+      "why": "ordering against an absent variable is an error; an error is HIDDEN, never shown",
+      "blocks": [{"kind": "badge", "label": {"en": "Open"}, "visible_when": "missing > 5"}],
+      "variables": [],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "visible-when-that-is-not-a-condition-hides",
+      "why": "the build refuses an empty condition, so this is a hand-edited manifest: it hides, exactly like an error",
+      "blocks": [{"kind": "badge", "label": {"en": "Open"}, "visible_when": ""}],
+      "variables": [],
+      "locale": "en",
+      "expect": []
+    },
+    {
+      "id": "duplicate-variable-id-resolves-to-the-first",
+      "why": "a room should never ship two variables of one id; if it does, both sides read the same one",
+      "blocks": [{"kind": "stat", "label": {"en": "Day"}, "value": {"$var": "day"}}],
+      "variables": [{"id": "day", "label": "day", "value": 1}, {"id": "day", "label": "day", "value": 2}],
+      "locale": "en",
+      "expect": [{"kind": "stat", "label": "Day", "value": 1}]
+    },
+    {
+      "id": "localization-falls-back-to-en",
+      "why": "this viewer's locale first, then en",
+      "blocks": [{"kind": "text", "text": {"en": "The gate"}}],
+      "variables": [],
+      "locale": "zh",
+      "expect": [{"kind": "text", "text": "The gate"}]
+    },
+    {
+      "id": "localization-falls-back-to-any-value",
+      "why": "and after en, whatever the map does carry — a panel in one language beats no panel",
+      "blocks": [{"kind": "text", "text": {"zh": "门"}}],
+      "variables": [],
+      "locale": "en",
+      "expect": [{"kind": "text", "text": "门"}]
+    }
+  ]
+}

--- a/tests/fixtures/panel_template_vectors.json
+++ b/tests/fixtures/panel_template_vectors.json
@@ -342,6 +342,30 @@
       "expect": [{"kind": "stat", "label": "Day", "value": 1}]
     },
     {
+      "id": "var-binding-with-extra-keys-is-still-a-binding",
+      "why": "the client tests `\"$var\" in value`, not \"exactly this one key\" — a dict that also carries other keys is a binding (the build refuses it anyway); pinned so neither side drifts back to \"exactly one key\", which once had the engine render the variable id as text",
+      "blocks": [{"kind": "stat", "label": "Day", "value": {"$var": "day", "extra": 1}}],
+      "variables": [{"id": "day", "label": "Day", "value": 15}],
+      "locale": "en",
+      "expect": [{"kind": "stat", "label": "Day", "value": 15}]
+    },
+    {
+      "id": "array-variable-value-picks-its-first-string",
+      "why": "an exposed MVU array leaf bound into a text field: the client treats any object as a locale map and falls through to Object.values, so the first non-empty string element is the text — the rich clients draw it, and the text fallback must not hide the block instead",
+      "blocks": [{"kind": "text", "text": {"$var": "mvu.notes"}}, {"kind": "stat", "label": "Tags", "value": {"$var": "mvu.tags"}}],
+      "variables": [{"id": "mvu.notes", "label": "notes", "value": ["", "first note", "second"]}, {"id": "mvu.tags", "label": "tags", "value": ["wet", "cold"]}],
+      "locale": "zh",
+      "expect": [{"kind": "text", "text": "first note"}, {"kind": "stat", "label": "Tags", "value": "wet"}]
+    },
+    {
+      "id": "array-variable-without-a-string-is-a-miss",
+      "why": "the other half of the same rule: an array of numbers has no text to pick, and a required text field with nothing to show hides its block",
+      "blocks": [{"kind": "text", "text": {"$var": "mvu.readings"}}],
+      "variables": [{"id": "mvu.readings", "label": "readings", "value": [16, 19, 22]}],
+      "locale": "en",
+      "expect": []
+    },
+    {
       "id": "localization-falls-back-to-en",
       "why": "this viewer's locale first, then en",
       "blocks": [{"kind": "text", "text": {"en": "The gate"}}],


### PR DESCRIPTION
## Summary
Panel template instantiation (blocks + a viewer's variables → resolved `ui` blocks) was implemented twice — `clients/tui/src/panelTemplates.ts` (reference client) and the server's `.panel` text fallback — and aligned by hand. Now it is structural, the way `visible_when_vectors.json` pins the condition grammar:

- `core.panels.resolve_panel_blocks` — pure, mirrors `resolvePanelBlocks` rule for rule over WIRE blocks; `render_panel_text` is a dumb stringify over its output; `.panel` feeds it wire blocks via `gateway.panels.panel_wire_blocks` (reusing the manifest's hashing; `core.panels.wire_panel_blocks` split out of `wire_panel`).
- `tests/fixtures/panel_template_vectors.json` — 41 cases; `tests/core/test_panel_template_vectors.py` and `clients/tui/src/panelTemplates.vectors.test.ts` both run it. The TypeScript stays the oracle; three rules had already drifted (empty `visible_when`, duplicate variable id, `{$var, extra}`) and the engine now copies the client.
- docs/plugins.md Layer D paragraph; `docs/notes/implemented/panel-template-vectors.md`.

Built by an Opus subagent from a written spec; reviewed line-by-line against `panelTemplates.ts` (PERFORMANCE_REQUIRED/OPTIONAL, BADGE_TONES, isVisible on empty, finiteNumber excluding bools, choices/prompt/option rules, repeat gate + cap, map_pin clamp) — no divergence from the oracle found.

## Test plan
- [x] ruff / i18n lint clean
- [x] `uv run pytest` — 2578 passed (41 new vector cases)
- [x] `bun test` tui 355 pass (one unrelated GameView test timed out under load, passes alone) / protocol 91 pass
- [ ] CI green