### PR TITLE
fix(backup): restore rooms as full checkpoints

### DIFF
--- a/docs/notes/implemented/room-import-checkpoint-replacement.md
+++ b/docs/notes/implemented/room-import-checkpoint-replacement.md
@@ -1,0 +1,23 @@
+# Implemented: room import is a full checkpoint replacement
+
+- **Problem:** `import_room` upserted the snapshot's KV / documents / `room_state`
+  / media and only deleted legacy aliases of incoming vector ids. Live rows the
+  snapshot did not name survived a `.save load`. History was already
+  delete-then-append, but `_capture_room_state` / `_rollback_room_state` omitted
+  the tree, so a later-leg failure restored documents/state/vectors/media/keys
+  and left chat history on the imported snapshot.
+- **Verdict:** a load replaces every exportable storage. Success leaves the
+  target room identical to the snapshot on documents, `room_state`, history,
+  vectors, media, and room-owned KV bindings. Failure rolls every mutated
+  storage — including history — back to the pre-import capture. Foreign
+  `bound_room.*` protection, media staged/created compensation, attempt-every-leg
+  rollback, and the undo-ring clear/restore stay as they were. Bearer keys stay
+  restore-only: they are identity, not campaign content, and a newer live key
+  is not erased.
+- **Reason:** a named save is a whole-room checkpoint. Merge semantics make
+  "the room after load" a mixture of two lives; a failed load that keeps the
+  new history is the same tear in the other direction.
+- **Rule home:** `net/room_backup.py` (`import_room`, `_replace_room_*`,
+  `_rollback_room_state`); AGENTS.md lifecycle paragraph (`room_backup` owns
+  order and atomicity).
+- **Date:** 2026-08-22.

--- a/docs/notes/implemented/room-lifecycle-facets.md
+++ b/docs/notes/implemented/room-lifecycle-facets.md
@@ -57,6 +57,13 @@
 - `import_room`'s undo-ring restore joined the attempt-every-leg rollback discipline
   instead of riding behind the other legs in one `try`.
 
+## Checkpoint replacement (2026-08-22)
+
+WS1 inverted ownership and made an uncarried storage clear on import. It did not
+change the carried-storage write from upsert-merge to replacement, and history
+stayed out of the capture/rollback snapshot. That follow-through is
+`docs/notes/implemented/room-import-checkpoint-replacement.md`.
+
 ## M23 tail cleanups (2026-08-14, same batch)
 
 Three small closure items from the post-M23 review, landed together on `m23-tail`:

--- a/net/room_backup.py
+++ b/net/room_backup.py
@@ -96,7 +96,9 @@ _VECTOR_OWNERSHIP_FIELDS = frozenset({"chat_key", "namespace"})
 # Which snapshot section carries each room-scoped storage. The export manifest is built
 # from this map, so a storage a facet lives in cannot quietly go uncarried — the
 # architecture test requires every facet storage to appear here or to be export-exempt,
-# and an export-exempt storage must be CLEARED on import (below) instead.
+# and an export-exempt storage must be CLEARED on import (below) instead. A load is a
+# whole-room checkpoint: each carried storage is replaced, not merged, so live rows the
+# snapshot does not name disappear with the export-exempt ones.
 EXPORT_SECTIONS: dict[str, str] = {
     STORAGE_DOCUMENTS: "documents",
     STORAGE_ROOM_STATE: "room_state",
@@ -338,12 +340,13 @@ async def _preflight_vector_import(
     points: list[tuple[str, list[float], dict[str, Any]]],
     chat_key: str,
 ) -> list[str]:
-    """Reject global id collisions and find obsolete aliases in the target room.
+    """Reject global id collisions before import mutates live state.
 
     Vector ids are global even though retrieval is payload-scoped. A same-room
-    point with the same id is an ordinary upsert; the same id owned by any other
-    room must fail before import mutates live state. Legacy backup aliases for the
-    same document/chunk are returned for removal after canonical points publish.
+    point with the same id is an ordinary replace; the same id owned by any other
+    room must fail closed. Legacy backup aliases for the same document/chunk are
+    still returned, but a checkpoint load wipes every room-owned point first, so
+    the caller no longer has to delete that list separately.
     """
     if not points:
         return []
@@ -647,6 +650,7 @@ class _RoomState:
     rows: list[dict[str, str | None]]
     documents: list[dict[str, Any]]
     state_rows: list[dict[str, str | None]]
+    history: list[dict[str, Any]]
     vectors: list[dict[str, Any]]
     keys: list[dict[str, str]]
     media: list[MediaRecord]
@@ -671,6 +675,7 @@ async def _capture_room_state(
         rows=rows,
         documents=await room_documents(services, chat_key, enforce_limits=False),
         state_rows=await room_state_rows(services, chat_key, enforce_limits=False),
+        history=await room_history_rows(services, chat_key, enforce_limits=False),
         vectors=await room_vector_points(services, chat_key, enforce_limits=False),
         keys=[
             {"key": entry.key, "room": entry.room, "name": entry.name, "role": entry.role}
@@ -850,6 +855,9 @@ async def _replace_room_content(
     rows: list[dict[str, Any]],
     documents: list[dict[str, Any]],
     state_rows: list[dict[str, Any]],
+    *,
+    clear_storages: tuple[str, list[str]] | None = None,
+    preserve_foreign_bindings: bool = True,
 ) -> None:
     current = await room_rows(services, chat_key, enforce_limits=False)
     await _atomic_store_update(
@@ -860,8 +868,27 @@ async def _replace_room_content(
         upsert_documents=documents,
         delete_state_room=chat_key,
         upsert_state=(chat_key, state_rows),
-        preserve_foreign_bindings=True,
+        clear_storages=clear_storages,
+        preserve_foreign_bindings=preserve_foreign_bindings,
     )
+
+
+async def _replace_room_history(
+    services: Services,
+    chat_key: str,
+    history_rows: list[dict[str, Any]],
+) -> None:
+    """Wipe the room's history tree and write `history_rows` in its place.
+
+    A named save is a whole-room checkpoint: rows the snapshot does not carry must
+    not survive the load, and a failed load must be able to put the captured tree
+    back the same way.
+    """
+    await services.store.history_delete_room(chat_key)
+    for key in {row["key"] for row in history_rows}:
+        await services.store.history_append(
+            chat_key, key, [row for row in history_rows if row["key"] == key]
+        )
 
 
 async def _delete_room_vectors(services: Services, chat_key: str) -> int:
@@ -1115,6 +1142,7 @@ async def _rollback_room_state(
         lambda: _restore_staged_media(services, staged_media),
         lambda: _replace_room_vectors(services, chat_key, state.vectors),
         lambda: _replace_room_content(services, chat_key, state.rows, state.documents, state.state_rows),
+        lambda: _replace_room_history(services, chat_key, state.history),
     ):
         try:
             await action()
@@ -1280,6 +1308,7 @@ async def delete_room_data(
             rows=state.rows,
             documents=state.documents,
             state_rows=state.state_rows,
+            history=state.history,
             vectors=state.vectors,
             keys=keys_before_delete,
             media=state.media,
@@ -1519,7 +1548,10 @@ async def import_room(
             raise ValueError("vector value limit exceeded")
         vector_ids.add(point_id)
         validated_vectors.append((point_id, [float(value) for value in vector], payload))
-    stale_vector_ids = await _preflight_vector_import(
+    # Collision check only: a same-id point owned by another room must fail before
+    # any live mutation. Room-owned leftovers are not listed here — the import
+    # replaces the whole room vector set rather than deleting aliases of incoming ids.
+    await _preflight_vector_import(
         vector_store,
         validated_vectors,
         new_chat_key,
@@ -1629,27 +1661,42 @@ async def import_room(
     # mutation it makes, and a ring only this code erased must come back with the rest.
     snapshots_before = await _capture_room_snapshots(services, new_chat_key)
     cleared_storages = sorted(room_registry().storages_not_exported())
+    # Live blobs the snapshot does not name are extras: they must leave on a successful
+    # load, and they must come back if a later leg fails. Stage them before any mutation
+    # so rollback can put the bytes back after the live copies are removed.
+    extra_media = [record for record in state.media if record.hash not in media_hashes]
+    stage_root: Path | None = None
+    staged_media: list[_StagedMedia] = []
+    if extra_media:
+        stage_root, staged_media = await _stage_room_media(services, new_chat_key, extra_media)
     created_media_hashes: set[str] = set()
     try:
-        await _atomic_store_update(
+        # A load is a checkpoint replacement, not a merge: wipe the live room's
+        # exportable rows, then write the snapshot.
+        await _replace_room_content(
             services,
-            upsert_rows=validated_rows,
-            upsert_documents=validated_documents,
-            upsert_state=(new_chat_key, validated_state),
+            new_chat_key,
+            validated_rows,
+            validated_documents,
+            validated_state,
             clear_storages=(new_chat_key, cleared_storages),
+            # A live binding that already names another room is a conflict, not a
+            # merge: fail the load rather than silently drop the snapshot row.
+            # Rollback (the default) skips that upsert so a concurrent rebind wins.
+            preserve_foreign_bindings=False,
         )
-        # The history tree rides outside that transaction because it is append-only:
-        # re-inserting a row that already exists is a no-op by construction, so a retry
-        # after a partial import converges rather than duplicating the conversation.
-        await services.store.history_delete_room(new_chat_key)
-        for key in {row["key"] for row in validated_history}:
-            await services.store.history_append(
-                new_chat_key, key, [row for row in validated_history if row["key"] == key]
-            )
-        if validated_vectors:
-            await vector_store.upsert(validated_vectors)
-        if stale_vector_ids:
-            await vector_store.delete(stale_vector_ids)
+        # History rides outside that transaction: the tree is append-only at the
+        # store API, so replacement is delete-then-append. A later-leg failure
+        # puts the captured tree back through the same helper.
+        await _replace_room_history(services, new_chat_key, validated_history)
+        await _replace_room_vectors(
+            services,
+            new_chat_key,
+            [
+                {"id": point_id, "vector": vector, "payload": payload}
+                for point_id, vector, payload in validated_vectors
+            ],
+        )
         for pending, data in validated_media:
             file_limit, quota_limit, allowed_mimes = _media_policy(services, pending.mime)
             existing = await media_store.validate_offer(
@@ -1664,6 +1711,12 @@ async def import_room(
             if existing is None:
                 await media_store.commit_bytes(pending, data)
                 created_media_hashes.add(pending.sha256)
+        if extra_media:
+            await _remove_imported_media(
+                services,
+                new_chat_key,
+                {record.hash for record in extra_media},
+            )
 
         imported_keys = 0
         with keystore.persisted_mutation():
@@ -1690,6 +1743,7 @@ async def import_room(
                 room,
                 new_chat_key,
                 state,
+                staged_media=staged_media,
                 imported_media=created_media_hashes,
             )
         except BaseException as rollback_exc:
@@ -1702,8 +1756,14 @@ async def import_room(
         except BaseException as ring_exc:
             rollback_errors.append(ring_exc)
         if rollback_errors:
+            # Keep the private staging directory for manual recovery if even compensation fails.
             raise RuntimeError("room import failed and rollback was incomplete") from rollback_errors[0]  # i18n-exempt
+        if stage_root is not None:
+            _discard_stage(stage_root)
         raise
+
+    if stage_root is not None:
+        _discard_stage(stage_root)
 
     return {
         "room": room,

--- a/tests/net/test_admin.py
+++ b/tests/net/test_admin.py
@@ -1515,6 +1515,116 @@ async def test_import_room_rolls_back_every_component_when_key_persistence_fails
         await media_store.read_bytes(chat_key, backup_media.hash)
 
 
+async def test_import_room_replaces_live_extras_the_snapshot_does_not_name(tmp_path):
+    """A load is a checkpoint, not a merge: extras added after export must vanish."""
+    services = _services(str(tmp_path))
+    keystore = Keystore()
+    keystore.add(room="arkham", name="Keeper", role="keeper")
+    chat_key = chat_key_for_room("arkham")
+    await services.documents.put(chat_key, "lore", "kept", {"title": "Kingsport"})
+    await services.store.state_set(chat_key, "game_clock", "snapshot-clock")
+    await services.store.set(user_key="", store_key="bound_room.discord:group:table", value=chat_key)
+    await services.vector_db.vector_store.upsert(
+        [("kept:0", [0.1] * 64, {"chat_key": chat_key, "document_id": "kept", "chunk_index": 0})]
+    )
+    media_store = MediaStore(
+        services.store,
+        services.settings.data_dir,
+        allowed_mimes=ALLOWED_MEDIA_MIMES,
+    )
+    kept_media = await media_store.register_blob(
+        room=chat_key,
+        data=b"kept handout",
+        mime="image/png",
+        name="kept.png",
+        uploader="keeper",
+    )
+    exported = await export_room(services, keystore, "arkham", "checkpoint.json")
+
+    await services.documents.put(chat_key, "lore", "extra", {"title": "after export"})
+    await services.store.state_set(chat_key, "kp_notes", "after-export")
+    await services.store.set(user_key="", store_key="bound_room.discord:group:extra", value=chat_key)
+    await services.vector_db.vector_store.upsert(
+        [("extra:0", [0.9] * 64, {"chat_key": chat_key, "document_id": "extra", "chunk_index": 0})]
+    )
+    extra_media = await media_store.register_blob(
+        room=chat_key,
+        data=b"extra handout",
+        mime="image/png",
+        name="extra.png",
+        uploader="keeper",
+    )
+
+    await import_room(
+        services,
+        keystore,
+        Path(exported["path"]).name,
+        expected_room="arkham",
+    )
+
+    docs = await services.store.doc_list(chat_key)
+    assert {(row["type"], row["id"]) for row in docs} == {("lore", "kept")}
+    assert await services.store.state_get(chat_key, "game_clock") == "snapshot-clock"
+    assert await services.store.state_get(chat_key, "kp_notes") is None
+    assert await services.store.get(store_key="bound_room.discord:group:table") == chat_key
+    assert await services.store.get(store_key="bound_room.discord:group:extra") is None
+    assert [point["id"] for point in await room_vector_points(services, chat_key)] == ["kept:0"]
+    assert [record.hash for record in await media_store.list_room_records(chat_key)] == [kept_media.hash]
+    with pytest.raises(MediaError, match="media_not_found"):
+        await media_store.read_bytes(chat_key, extra_media.hash)
+
+
+async def test_import_rollback_restores_history_after_a_later_leg_fails(tmp_path):
+    """History is replaced before vectors/media/keys; a later failure must put it back."""
+    services = _services(str(tmp_path))
+    keystore = Keystore()
+    keystore.add(room="arkham", name="Keeper", role="keeper")
+    chat_key = chat_key_for_room("arkham")
+    await services.store.history_append(
+        chat_key,
+        "chat_history",
+        [{"id": "snap-1", "parent_id": None, "turn": 1, "role": "user", "content": "snapshot line"}],
+    )
+    media_store = MediaStore(
+        services.store,
+        services.settings.data_dir,
+        allowed_mimes=ALLOWED_MEDIA_MIMES,
+    )
+    await media_store.register_blob(
+        room=chat_key,
+        data=b"snapshot handout",
+        mime="image/png",
+        name="snap.png",
+        uploader="keeper",
+    )
+    exported = await export_room(services, keystore, "arkham", "history-rollback.json")
+
+    await services.store.history_delete_room(chat_key)
+    await services.store.history_append(
+        chat_key,
+        "chat_history",
+        [{"id": "live-1", "parent_id": None, "turn": 2, "role": "user", "content": "live line"}],
+    )
+    original_history = await services.store.history_rows(chat_key)
+    assert [row["id"] for row in original_history] == ["live-1"]
+
+    async def _fail_after_history(_instance, **_kwargs):
+        replaced = await services.store.history_rows(chat_key)
+        assert [row["id"] for row in replaced] == ["snap-1"]
+        raise OSError("injected import failure after history replace")
+
+    with patch.object(MediaStore, "validate_offer", new=_fail_after_history):
+        with pytest.raises(OSError, match="after history replace"):
+            await import_room(
+                services,
+                keystore,
+                Path(exported["path"]).name,
+                expected_room="arkham",
+            )
+
+    assert await services.store.history_rows(chat_key) == original_history
+
+
 async def test_admin_room_ops_are_scoped_to_the_callers_room():
     """Security: a keeper key bound to room A cannot mutate/export/wipe/import room B — only its
     own room, including listing/minting/mutating access keys."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore checkpoints by replacing room-owned KV/documents/state/history/vectors/media instead of merging
- include chat history in failed-import compensation
- preserve foreign binding and bearer-key semantics
- document checkpoint replacement

## Tests
- full backend pytest, Ruff, and i18n
- targeted import/rollback/lifecycle coverage
- combined all-PR integration suite
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8df0c996-410d-4440-a105-824b093328bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8df0c996-410d-4440-a105-824b093328bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

