### PR TITLE
fix(protocol): validate nested server frames

### DIFF
--- a/clients/bun.lock
+++ b/clients/bun.lock
@@ -7,7 +7,7 @@
     },
     "protocol": {
       "name": "loreweaver-protocol",
-      "version": "1.7.0",
+      "version": "2.3.2",
       "devDependencies": {
         "typescript": "^5.5.0",
       },

--- a/clients/protocol/package.json
+++ b/clients/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loreweaver-protocol",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Typed wire-protocol frames and a reconnecting WebSocket client for Loreweaver, the self-hosted AI Game Master / Keeper (protocol v2.3).",
   "type": "module",
   "license": "MIT",

--- a/clients/protocol/src/client.test.ts
+++ b/clients/protocol/src/client.test.ts
@@ -158,6 +158,9 @@ describe("WsClient", () => {
       type: FrameType.PackCards,
       cards: [{ ref: "harbour/cards/pilot.json", pack: "harbour", name: "pilot" }],
     })
+    sockets[0].serverSend({ type: FrameType.PackCards, cards: [null] })
+    sockets[0].serverSend({ type: FrameType.PackCards, cards: ["harbour/cards/pilot.json"] })
+    sockets[0].serverSend({ type: FrameType.PackCards, cards: [{ pack: "harbour", name: "pilot" }] })
     expect(cards).toEqual(["harbour/cards/pilot.json"])
   })
 
@@ -231,6 +234,13 @@ describe("WsClient", () => {
 
     // Right `type`, but missing the load-bearing fields the consumers read.
     sockets[0].serverSend({ type: FrameType.State }) // no party / initiative
+    sockets[0].serverSend({ type: FrameType.State, party: [null], initiative: [], online: 1 })
+    sockets[0].serverSend({ type: FrameType.State, party: ["Nora"], initiative: [], online: 1 })
+    sockets[0].serverSend({ type: FrameType.State, party: [], initiative: [null], online: 1 })
+    sockets[0].serverSend({ type: FrameType.AudioState, layers: [null] })
+    sockets[0].serverSend({ type: FrameType.AudioState, layers: ["bgm"] })
+    sockets[0].serverSend({ type: FrameType.Presence, players: [null], online: 1 })
+    sockets[0].serverSend({ type: FrameType.Presence, players: ["Ada"], online: 1 })
     sockets[0].serverSend({ type: FrameType.Narrative, id: "x" }) // no speaker / text
     sockets[0].serverSend({ type: FrameType.System, level: "info" }) // no text
     sockets[0].serverSend({ type: "totally-unknown" }) // unknown type
@@ -267,6 +277,8 @@ describe("WsClient", () => {
       online: 1,
       variables,
     } satisfies StateFrame)
+    sockets[0].serverSend({ type: FrameType.State, party: [], initiative: [], online: 1, variables: [null] })
+    sockets[0].serverSend({ type: FrameType.State, party: [], initiative: [], online: 1, variables: [{ id: "x" }] })
     // An older server omits the field entirely (never an empty array): the frame
     // still validates + dispatches, and the consumer sees `undefined`.
     sockets[0].serverSend({ type: FrameType.State, party: [], initiative: [], online: 1 } satisfies StateFrame)
@@ -303,6 +315,9 @@ describe("WsClient", () => {
     // Malformed variants of the load-bearing fields are dropped, not dispatched.
     sockets[0].serverSend({ type: FrameType.Ui, panel: "inline" }) // no blocks
     sockets[0].serverSend({ type: FrameType.Ui, blocks: [] }) // no panel
+    sockets[0].serverSend({ type: FrameType.Ui, panel: "inline", blocks: [null] })
+    sockets[0].serverSend({ type: FrameType.Ui, panel: "inline", blocks: ["meter"] })
+    sockets[0].serverSend({ type: FrameType.Ui, panel: "inline", blocks: [{ kind: "meter", label: "Fear" }] })
 
     expect(seen).toHaveLength(2)
     expect(seen[0].blocks).toEqual(blocks) // block order preserved, content untouched
@@ -461,7 +476,9 @@ describe("WsClient", () => {
       override_active: false,
     })
     sockets[0].serverSend({ type: FrameType.AdminModels, provider: "openai", models: ["gpt-4o", "gpt-4o-mini"] })
+    sockets[0].serverSend({ type: FrameType.AdminModels, provider: "openai", models: [null] })
     sockets[0].serverSend({ type: FrameType.AdminKeys, keys: [] })
+    sockets[0].serverSend({ type: FrameType.AdminKeys, keys: [null] })
     sockets[0].serverSend({
       type: FrameType.AdminRoomOp,
       action: "export",
@@ -473,6 +490,16 @@ describe("WsClient", () => {
       media_files: 4,
     })
     sockets[0].serverSend({ type: FrameType.AdminError, code: "forbidden" })
+    sockets[0].serverSend({
+      type: FrameType.AdminConfig,
+      provider: "openai",
+      chat_model: "gpt-4o",
+      base_url: "",
+      api_key_masked: "",
+      providers: [null],
+      saved_providers: [],
+      override_active: false,
+    })
 
     expect(seen).toEqual([
       FrameType.AdminConfig,
@@ -514,7 +541,9 @@ describe("WsClient", () => {
     })
     // Malformed variants of each are dropped, not dispatched.
     sockets[0].serverSendRaw(JSON.stringify({ type: FrameType.AdminSkills })) // no `skills`
+    sockets[0].serverSendRaw(JSON.stringify({ type: FrameType.AdminSkills, skills: [null] }))
     sockets[0].serverSendRaw(JSON.stringify({ type: FrameType.AdminRules })) // no `systems`
+    sockets[0].serverSendRaw(JSON.stringify({ type: FrameType.AdminRules, systems: [null] }))
     sockets[0].serverSendRaw(JSON.stringify({ type: FrameType.AdminGenerated, kind: "skill" })) // no `ok`
 
     expect(seen).toEqual([FrameType.AdminSkills, FrameType.AdminRules, FrameType.AdminGenerated])
@@ -580,6 +609,9 @@ describe("module UI panels (v1.8)", () => {
       panels: [{ id: "pack/board", title: { en: "Board" }, slot: "sidebar", tier: 1, blocks: [] }],
     })
     sockets[0].serverSend({ type: "ui_manifest" }) // no panels array -> dropped
+    sockets[0].serverSend({ type: "ui_manifest", panels: [null] })
+    sockets[0].serverSend({ type: "ui_manifest", panels: ["pack/board"] })
+    sockets[0].serverSend({ type: "ui_manifest", panels: [{ title: { en: "Board" }, slot: "sidebar", tier: 1 }] })
     sockets[0].serverSend({ type: "panel_event", panel: "pack/board", payload: { clue: 1 } })
     sockets[0].serverSend({ type: "panel_event", panel: "pack/board" }) // opaque payload may be absent
     sockets[0].serverSend({ type: "panel_event", panel: "" }) // no target panel -> dropped

--- a/clients/protocol/src/client.ts
+++ b/clients/protocol/src/client.ts
@@ -1,5 +1,23 @@
 import {
+  ADMIN_FORGE_KINDS,
+  ADMIN_KEY_PURPOSES,
+  ADMIN_ROOM_OP_ACTIONS,
+  AUDIO_ACTIONS,
+  AUDIO_LAYERS,
+  DICE_KINDS,
   FrameType,
+  MODULE_VARIABLE_KINDS,
+  NARRATIVE_FORMATS,
+  NARRATIVE_SPEAKERS,
+  PACK_CARD_KINDS,
+  PANEL_LEAF_FIELDS,
+  PANEL_SLOTS,
+  PLAYER_ROLES,
+  SYSTEM_LEVELS,
+  UI_BADGE_TONES,
+  UI_BLOCK_KINDS,
+  UI_PANELS,
+  UI_TEXT_STYLES,
   type AdminDeleteRoomDataFrame,
   type AdminEnableSkillFrame,
   type AdminExportRoomFrame,
@@ -86,55 +104,497 @@ const OPEN = 1
 const WS_MEDIA_HEADER_BYTES = 4
 
 function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 const isStr = (v: unknown): v is string => typeof v === "string"
-const isNum = (v: unknown): v is number => typeof v === "number"
+const isNum = (v: unknown): v is number => typeof v === "number" && Number.isFinite(v)
+const isBool = (v: unknown): v is boolean => typeof v === "boolean"
 const isArr = Array.isArray
 
-// Per-frame-type validation of the load-bearing required fields. A frame that
-// passes the `type` check but is missing/mistyped these (e.g. `{"type":"state"}`
-// with no party/initiative, or a narrative with no speaker/text) is DROPPED here
-// so it can never crash a downstream consumer (`.map`/`.length`/`.toUpperCase`
-// on `undefined` in the web panels and the TUI). One validator table protects
-// every client.
+function isOneOf<T extends string>(value: unknown, allowed: readonly T[]): value is T {
+  return typeof value === "string" && (allowed as readonly string[]).includes(value)
+}
+
+function optional(value: unknown, check: (v: unknown) => boolean): boolean {
+  return value === undefined || check(value)
+}
+
+function everyItem(value: unknown, check: (item: unknown) => boolean): boolean {
+  return isArr(value) && value.every(check)
+}
+
+function isStringList(value: unknown): value is string[] {
+  return everyItem(value, isStr)
+}
+
+/** Content-addressed media blob. Downstream fetches by `hash` and reads `mime`/`size`. */
+function isMediaRef(value: unknown): boolean {
+  return isObject(value) && isStr(value.hash) && isStr(value.mime) && isNum(value.size) && optional(value.name, isStr)
+}
+
+function isMediaFrameFields(value: Record<string, unknown>): boolean {
+  return (
+    isMediaRef(value) &&
+    isStr(value.id) &&
+    isStr(value.name) &&
+    isStr(value.from) &&
+    isNum(value.ts)
+  )
+}
+
+function isAudioLibraryItem(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isMediaFrameFields(value) &&
+    optional(value.title, isStr) &&
+    optional(value.license, isStr) &&
+    optional(value.source, isStr) &&
+    optional(value.tags, isStringList)
+  )
+}
+
+function isWelcomeYou(value: unknown): boolean {
+  return isObject(value) && isStr(value.id) && isStr(value.name) && isOneOf(value.role, PLAYER_ROLES)
+}
+
+function isResourceState(value: unknown): boolean {
+  return isObject(value) && isStr(value.id) && isStr(value.label) && isNum(value.value) && optional(value.max, isNum)
+}
+
+function isCharacterState(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isStr(value.name) &&
+    isStr(value.system) &&
+    everyItem(value.resources, isResourceState) &&
+    isObject(value.attributes) &&
+    isStringList(value.status_effects) &&
+    optional(value.avatar, isMediaRef)
+  )
+}
+
+function isPartyMember(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isStr(value.name) &&
+    isBool(value.online) &&
+    isBool(value.active) &&
+    optional(value.initiative, isNum) &&
+    optional(value.resources, (v) => everyItem(v, isResourceState)) &&
+    optional(value.ai, isBool) &&
+    optional(value.avatar, isMediaRef)
+  )
+}
+
+function isInitiativeEntry(value: unknown): boolean {
+  return isObject(value) && isStr(value.name) && isNum(value.value) && isBool(value.current)
+}
+
+function isUsageState(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isNum(value.context_tokens) &&
+    isNum(value.context_window) &&
+    isNum(value.input_tokens) &&
+    isNum(value.output_tokens) &&
+    isNum(value.cache_hit_tokens) &&
+    isNum(value.cache_miss_tokens)
+  )
+}
+
+function isModuleVariable(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isStr(value.id) &&
+    isStr(value.label) &&
+    isOneOf(value.kind, MODULE_VARIABLE_KINDS) &&
+    (isNum(value.value) || isBool(value.value) || isStr(value.value)) &&
+    optional(value.min, isNum) &&
+    optional(value.max, isNum) &&
+    optional(value.hidden, isBool)
+  )
+}
+
+function isPregenEntry(value: unknown): boolean {
+  return isObject(value) && isStr(value.name) && isStr(value.claimed_by)
+}
+
+function isRuleSystemEntry(value: unknown): boolean {
+  return isObject(value) && isStr(value.id) && optional(value.make_char, isStr)
+}
+
+function isSceneState(value: unknown): boolean {
+  return isObject(value) && isStr(value.name) && optional(value.focus, isStr)
+}
+
+function isClockState(value: unknown): boolean {
+  return isObject(value) && isStr(value.time) && optional(value.round, isNum)
+}
+
+function isPresencePlayer(value: unknown): boolean {
+  return isObject(value) && isStr(value.id) && isStr(value.name) && isBool(value.online)
+}
+
+function isAudioLayerState(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isOneOf(value.layer, AUDIO_LAYERS) &&
+    isBool(value.playing) &&
+    optional(value.hash, isStr) &&
+    optional(value.mime, isStr) &&
+    optional(value.name, isStr) &&
+    optional(value.title, isStr) &&
+    optional(value.volume, isNum) &&
+    optional(value.loop, isBool) &&
+    optional(value.started_at, isNum)
+  )
+}
+
+function isPackCardEntry(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isStr(value.ref) &&
+    isStr(value.pack) &&
+    isStr(value.name) &&
+    optional(value.kind, (v) => isOneOf(v, PACK_CARD_KINDS))
+  )
+}
+
+function isDiceOutcome(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isStr(value.id) &&
+    isStr(value.label) &&
+    isBool(value.success) &&
+    isBool(value.critical) &&
+    isBool(value.fumble) &&
+    isNum(value.tier) &&
+    optional(value.margin, isNum)
+  )
+}
+
+function isUiChoiceOption(value: unknown): boolean {
+  return isObject(value) && isStr(value.id) && isStr(value.label) && isStr(value.input)
+}
+
+function isKnownUiBlockKind(kind: string): kind is (typeof UI_BLOCK_KINDS)[number] {
+  return (UI_BLOCK_KINDS as readonly string[]).includes(kind)
+}
+
+/** Hook `ui` blocks: object + kind; known kinds check their required fields.
+ * An unknown kind is additive and passes so a newer server can ship a new
+ * template without dropping the whole frame. null / primitives never pass. */
+function isUiBlock(value: unknown): boolean {
+  if (!isObject(value) || !isStr(value.kind)) return false
+  if (!isKnownUiBlockKind(value.kind)) return true
+  switch (value.kind) {
+    case "meter":
+      return isStr(value.label) && isNum(value.value) && isNum(value.min) && isNum(value.max)
+    case "stat":
+      return isStr(value.label) && (isNum(value.value) || isStr(value.value) || isBool(value.value))
+    case "badge":
+      return isStr(value.label) && optional(value.tone, (v) => isOneOf(v, UI_BADGE_TONES))
+    case "text":
+      return isStr(value.text) && optional(value.style, (v) => isOneOf(v, UI_TEXT_STYLES))
+    case "divider":
+      return true
+    case "choices":
+      return optional(value.prompt, isStr) && everyItem(value.options, isUiChoiceOption)
+    case "image":
+      return isStr(value.hash) && optional(value.mime, isStr) && optional(value.size, isNum)
+    case "letter":
+      return isStr(value.body)
+    case "clipping":
+      return isStr(value.headline) && isStr(value.body)
+    case "map_pin":
+      return isStr(value.hash) && isStr(value.label) && isNum(value.x) && isNum(value.y)
+    case "title_card":
+      return isStr(value.title)
+  }
+}
+
+function isPanelText(value: unknown): boolean {
+  return isObject(value) && optional(value.en, isStr) && optional(value.zh, isStr)
+}
+
+function isPanelVarBinding(value: unknown): boolean {
+  return isObject(value) && isStr(value.$var)
+}
+
+function isPanelLeafBinding(value: unknown): boolean {
+  return isObject(value) && isOneOf(value.$leaf, PANEL_LEAF_FIELDS)
+}
+
+function isPanelTextValue(value: unknown): boolean {
+  return isPanelText(value) || isPanelVarBinding(value) || isPanelLeafBinding(value)
+}
+
+function isPanelBindableNumber(value: unknown): boolean {
+  return isNum(value) || isPanelVarBinding(value) || isPanelLeafBinding(value)
+}
+
+function isPanelBindableScalar(value: unknown): boolean {
+  return isNum(value) || isStr(value) || isBool(value) || isPanelVarBinding(value) || isPanelLeafBinding(value)
+}
+
+function isPanelChoiceOption(value: unknown): boolean {
+  return isObject(value) && isStr(value.id) && isPanelTextValue(value.label) && isStr(value.input)
+}
+
+/** One `repeat` wrapper. The inner template is checked with `allowRepeat=false`
+ * so a nested / thousand-deep `repeat` tree is a flat reject, not a walk.
+ * Protocol and Studio both say repeat does not nest — this is that rule. */
+function isPanelRepeat(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isObject(value.repeat) &&
+    isStr(value.repeat.prefix) &&
+    isPanelTemplateBlock(value.repeat.block, false)
+  )
+}
+
+/** Panel template blocks: object + kind (or `repeat`) + that kind's required
+ * fields. Bindings (`$var` / `$leaf`) count as present. Unknown kinds pass.
+ * `allowRepeat` is true only at the panel `blocks` / `fallback` root; the
+ * inner of a repeat must be a kind (or unknown-kind object), never another
+ * repeat. This is the only recursive validator pair, and it is bounded to
+ * one level. The flag is required (no default) so it cannot be confused
+ * with `Array.every`'s index argument. */
+function isPanelTemplateBlock(value: unknown, allowRepeat: boolean): boolean {
+  if (!isObject(value)) return false
+  if (optional(value.visible_when, isStr) === false) return false
+  if ("repeat" in value) return allowRepeat && isPanelRepeat(value)
+  if (!isStr(value.kind)) return false
+  if (!isKnownUiBlockKind(value.kind)) return true
+  switch (value.kind) {
+    case "meter":
+      return (
+        isPanelTextValue(value.label) &&
+        isPanelBindableNumber(value.value) &&
+        isPanelBindableNumber(value.min) &&
+        isPanelBindableNumber(value.max)
+      )
+    case "stat":
+      return isPanelTextValue(value.label) && isPanelBindableScalar(value.value)
+    case "badge":
+      return (
+        isPanelTextValue(value.label) &&
+        optional(value.tone, (v) => isOneOf(v, UI_BADGE_TONES) || isPanelVarBinding(v) || isPanelLeafBinding(v))
+      )
+    case "text":
+      return isPanelTextValue(value.text) && optional(value.style, (v) => isOneOf(v, UI_TEXT_STYLES))
+    case "divider":
+      return true
+    case "choices":
+      return optional(value.prompt, isPanelTextValue) && everyItem(value.options, isPanelChoiceOption)
+    case "image":
+      return isStr(value.hash) && isStr(value.mime) && isNum(value.size)
+    case "letter":
+      return isPanelTextValue(value.body)
+    case "clipping":
+      return isPanelTextValue(value.headline) && isPanelTextValue(value.body)
+    case "map_pin":
+      return (
+        isStr(value.hash) &&
+        isStr(value.mime) &&
+        isNum(value.size) &&
+        isPanelTextValue(value.label) &&
+        isPanelBindableNumber(value.x) &&
+        isPanelBindableNumber(value.y)
+      )
+    case "title_card":
+      return isPanelTextValue(value.title)
+  }
+}
+
+function isPanelAssetRef(value: unknown): boolean {
+  return isObject(value) && isStr(value.path) && isStr(value.hash) && isNum(value.size) && isStr(value.mime)
+}
+
+function isUiManifestPanel(value: unknown): boolean {
+  if (!isObject(value) || !isStr(value.id) || !isPanelText(value.title)) return false
+  if (!isOneOf(value.slot, PANEL_SLOTS) || (value.tier !== 1 && value.tier !== 2)) return false
+  if (!optional(value.blocks, (v) => everyItem(v, (item) => isPanelTemplateBlock(item, true)))) return false
+  if (
+    !optional(
+      value.entry,
+      (v) => isObject(v) && isStr(v.hash) && isNum(v.size),
+    )
+  ) {
+    return false
+  }
+  if (!optional(value.assets, (v) => everyItem(v, isPanelAssetRef))) return false
+  if (value.fallback === null) return true
+  return optional(value.fallback, (v) => everyItem(v, (item) => isPanelTemplateBlock(item, true)))
+}
+
+function isImageGenStatus(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isStr(value.provider) &&
+    isStr(value.base_url) &&
+    isStr(value.model) &&
+    isStr(value.size) &&
+    isStr(value.api_key_masked) &&
+    isBool(value.has_key) &&
+    isBool(value.configured) &&
+    optional(value.saved_providers, isStringList)
+  )
+}
+
+function isAdminKeyInfo(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isStr(value.id) &&
+    isStr(value.key_masked) &&
+    isStr(value.room) &&
+    isStr(value.name) &&
+    isOneOf(value.role, PLAYER_ROLES) &&
+    isOneOf(value.purpose, ADMIN_KEY_PURPOSES) &&
+    (value.expires_at === null || isNum(value.expires_at))
+  )
+}
+
+function isMintedKey(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isStr(value.key) &&
+    isStr(value.room) &&
+    isStr(value.name) &&
+    isOneOf(value.role, PLAYER_ROLES) &&
+    isOneOf(value.purpose, ADMIN_KEY_PURPOSES) &&
+    (value.expires_at === null || isNum(value.expires_at))
+  )
+}
+
+function isAdminSkillInfo(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    isStr(value.id) &&
+    isStr(value.name) &&
+    isStr(value.description) &&
+    isStr(value.content_rating) &&
+    isBool(value.enabled)
+  )
+}
+
+function isAdminRuleInfo(value: unknown): boolean {
+  return isObject(value) && isStr(value.id) && isBool(value.built_in)
+}
+
+// Per-frame-type validation of the load-bearing required fields AND the nested
+// shapes downstream clients dereference (`.map`, `.id`, `layers[wire.layer]`,
+// `you.role`, …). A frame that passes the `type` check but carries null /
+// primitive / missing-required entries in those arrays is DROPPED here so it
+// can never crash a consumer. Unknown extra fields and unknown frame types
+// stay additive (ignored, not rejected). One validator table protects every
+// client.
 const serverFrameValidators: Record<string, (f: Record<string, unknown>) => boolean> = {
-  [FrameType.Welcome]: (f) => isStr(f.room) && isObject(f.you) && isStr(f.you.name) && isStr(f.you.role),
+  [FrameType.Welcome]: (f) =>
+    isStr(f.protocol) &&
+    isStr(f.room) &&
+    isWelcomeYou(f.you) &&
+    isStr(f.locale) &&
+    isStr(f.server) &&
+    optional(f.features, isStringList) &&
+    optional(f.version, isStr),
   [FrameType.Error]: (f) => isStr(f.code) && isStr(f.message),
-  [FrameType.MediaAccept]: (f) => isStr(f.upload_id),
-  [FrameType.Media]: (f) =>
-    isStr(f.id) && isStr(f.hash) && isStr(f.mime) && isNum(f.size) && isStr(f.name) && isStr(f.from) && isNum(f.ts),
-  [FrameType.MediaEnabled]: (f) => typeof f.enabled === "boolean",
-  [FrameType.AudioLibraryItem]: (f) =>
-    isStr(f.id) && isStr(f.hash) && isStr(f.mime) && isNum(f.size) && isStr(f.name) && isStr(f.from) && isNum(f.ts),
-  [FrameType.AudioControl]: (f) => isStr(f.id) && isStr(f.action) && isStr(f.layer),
-  [FrameType.AudioState]: (f) => isArr(f.layers),
-  [FrameType.Narrative]: (f) => isStr(f.id) && isStr(f.speaker) && isStr(f.text),
-  [FrameType.NarrativeDelta]: (f) => isStr(f.id) && isStr(f.speaker) && isStr(f.text),
-  [FrameType.PackCards]: (f) => isArr(f.cards),
-  [FrameType.Dice]: (f) => isStr(f.actor) && isStr(f.expr) && isNum(f.total),
-  [FrameType.Ui]: (f) => isArr(f.blocks) && isStr(f.panel),
-  // v1.8 module panels: a manifest is a full-replace panel list; a panel event names
-  // its target panel (payload is opaque JSON and may legitimately be null/absent).
-  [FrameType.UiManifest]: (f) => isArr(f.panels),
+  [FrameType.MediaAccept]: (f) =>
+    isStr(f.upload_id) &&
+    optional(f.existing, isBool) &&
+    optional(f.media, (v) => isObject(v) && v.type === FrameType.Media && isMediaFrameFields(v)) &&
+    optional(f.audio, isAudioLibraryItem),
+  [FrameType.Media]: (f) => isMediaFrameFields(f),
+  [FrameType.MediaEnabled]: (f) => isBool(f.enabled),
+  [FrameType.AudioLibraryItem]: (f) => isAudioLibraryItem(f),
+  [FrameType.AudioControl]: (f) =>
+    isStr(f.id) &&
+    isOneOf(f.action, AUDIO_ACTIONS) &&
+    isOneOf(f.layer, AUDIO_LAYERS) &&
+    optional(f.hash, isStr) &&
+    optional(f.mime, isStr) &&
+    optional(f.name, isStr) &&
+    optional(f.title, isStr) &&
+    optional(f.loop, isBool) &&
+    optional(f.volume, isNum) &&
+    optional(f.fade_ms, isNum) &&
+    optional(f.position_ms, isNum) &&
+    optional(f.server_ts, isNum),
+  [FrameType.AudioState]: (f) => everyItem(f.layers, isAudioLayerState),
+  [FrameType.Narrative]: (f) =>
+    isStr(f.id) && isOneOf(f.speaker, NARRATIVE_SPEAKERS) && isStr(f.text) && isOneOf(f.format, NARRATIVE_FORMATS),
+  [FrameType.NarrativeDelta]: (f) => isStr(f.id) && isOneOf(f.speaker, NARRATIVE_SPEAKERS) && isStr(f.text),
+  [FrameType.PackCards]: (f) => everyItem(f.cards, isPackCardEntry),
+  [FrameType.Dice]: (f) =>
+    isStr(f.actor) &&
+    isOneOf(f.kind, DICE_KINDS) &&
+    isStr(f.expr) &&
+    everyItem(f.rolls, isNum) &&
+    isNum(f.total) &&
+    optional(f.target, isNum) &&
+    optional(f.effective_target, isNum) &&
+    optional(f.subsystem, isStr) &&
+    optional(f.outcome, isDiceOutcome) &&
+    optional(f.detail, isObject),
+  [FrameType.Ui]: (f) => everyItem(f.blocks, isUiBlock) && isOneOf(f.panel, UI_PANELS),
+  [FrameType.UiManifest]: (f) => everyItem(f.panels, isUiManifestPanel),
   [FrameType.PanelEvent]: (f) => isStr(f.panel) && f.panel.length > 0,
-  [FrameType.State]: (f) => isArr(f.party) && isArr(f.initiative) && isNum(f.online),
-  [FrameType.Presence]: (f) => isArr(f.players) && isNum(f.online),
-  [FrameType.System]: (f) => isStr(f.level) && isStr(f.text),
+  [FrameType.State]: (f) =>
+    optional(f.character, isCharacterState) &&
+    everyItem(f.party, isPartyMember) &&
+    optional(f.scene, isSceneState) &&
+    optional(f.clock, isClockState) &&
+    everyItem(f.initiative, isInitiativeEntry) &&
+    isNum(f.online) &&
+    optional(f.usage, isUsageState) &&
+    optional(f.variables, (v) => everyItem(v, isModuleVariable)) &&
+    optional(f.pregens, (v) => everyItem(v, isPregenEntry)) &&
+    optional(f.systems, (v) => everyItem(v, isRuleSystemEntry)) &&
+    optional(f.reset, isBool),
+  [FrameType.Presence]: (f) => everyItem(f.players, isPresencePlayer) && isNum(f.online),
+  [FrameType.System]: (f) => isOneOf(f.level, SYSTEM_LEVELS) && isStr(f.text) && optional(f.spinner, isBool),
   [FrameType.TurnStatus]: (f) =>
-    (f.status === "busy" && isStr(f.actor) && f.actor.length > 0) || f.status === "idle",
+    (f.status === "busy" &&
+      isStr(f.actor) &&
+      f.actor.length > 0 &&
+      optional(f.activity, isStr) &&
+      optional(f.round, isNum)) ||
+    f.status === "idle",
   [FrameType.Pong]: (f) => isNum(f.t),
-  [FrameType.AdminConfig]: (f) => isStr(f.provider) && isStr(f.chat_model) && isArr(f.providers),
-  [FrameType.AdminModels]: (f) => isStr(f.provider) && isArr(f.models),
-  [FrameType.AdminKeys]: (f) => isArr(f.keys),
+  [FrameType.AdminConfig]: (f) =>
+    isStr(f.provider) &&
+    isStr(f.chat_model) &&
+    isStr(f.base_url) &&
+    isStr(f.api_key_masked) &&
+    isStringList(f.providers) &&
+    isStringList(f.saved_providers) &&
+    isBool(f.override_active) &&
+    optional(f.imagegen, isImageGenStatus) &&
+    optional(f.using_demo, isBool) &&
+    optional(f.subscription_status, (v) => v === "" || v === "logged_in" || v === "logged_out"),
+  [FrameType.AdminModels]: (f) => isStr(f.provider) && isStringList(f.models) && optional(f.imagegen, isImageGenStatus),
+  [FrameType.AdminKeys]: (f) => everyItem(f.keys, isAdminKeyInfo) && optional(f.minted, isMintedKey),
   [FrameType.AdminRoomOp]: (f) =>
-    isStr(f.action) && isStr(f.room) && isNum(f.keys) && isNum(f.store_rows) && isNum(f.vector_points),
-  [FrameType.AdminError]: (f) => isStr(f.code),
-  [FrameType.AdminSkills]: (f) => isArr(f.skills),
-  [FrameType.AdminRules]: (f) => isArr(f.systems),
-  [FrameType.AdminGenerated]: (f) => isStr(f.kind) && typeof f.ok === "boolean",
-  [FrameType.AdminUpdate]: (f) => isStr(f.status),
+    isOneOf(f.action, ADMIN_ROOM_OP_ACTIONS) &&
+    isStr(f.room) &&
+    isNum(f.keys) &&
+    isNum(f.store_rows) &&
+    isNum(f.vector_points) &&
+    optional(f.path, isStr) &&
+    optional(f.media_files, isNum) &&
+    optional(f.scope, isStr),
+  [FrameType.AdminError]: (f) => isStr(f.code) && optional(f.message, isStr),
+  [FrameType.AdminSkills]: (f) => everyItem(f.skills, isAdminSkillInfo),
+  [FrameType.AdminRules]: (f) => everyItem(f.systems, isAdminRuleInfo),
+  [FrameType.AdminGenerated]: (f) =>
+    isOneOf(f.kind, ADMIN_FORGE_KINDS) &&
+    isBool(f.ok) &&
+    optional(f.id, isStr) &&
+    optional(f.name, isStr) &&
+    optional(f.error, isStr) &&
+    optional(f.detail, isStr),
+  [FrameType.AdminUpdate]: (f) => (f.status === "restarting" || f.status === "failed") && optional(f.output, isStr),
 }
 
 function defaultWebSocketFactory(url: string): WebSocketLike {

--- a/clients/protocol/src/types.ts
+++ b/clients/protocol/src/types.ts
@@ -73,46 +73,71 @@ export const FrameType = {
 
 export type FrameType = (typeof FrameType)[keyof typeof FrameType]
 
-export type PlayerRole = "player" | "keeper"
-export type AdminKeyPurpose = "join" | "chat_bind"
-export type NarrativeSpeaker = "kp" | "player" | "system" | "npc"
-export type NarrativeFormat = "markdown" | "plain"
-export type ErrorCode =
-  | "bad_key"
-  | "bad_frame"
-  | "input_too_long"
-  | "rate_limited"
-  | "server_error"
-  | "join_timeout"
-  | "too_many_connections"
-  | "forbidden"
-  | "media_disabled"
-  | "media_rate_limited"
-  | "media_bad_mime"
-  | "media_too_large"
-  | "media_quota_exceeded"
-  | "media_bad_hash"
-  | "media_bad_offer"
-  | "media_bad_svg"
-  | "media_bad_upload"
-  | "media_size_mismatch"
-  | "media_hash_mismatch"
-  | "media_not_found"
-  | "avatar_no_character"
-export type DiceKind = "roll" | "check" | "subsystem" | "opposed" | "init"
-export type SystemLevel = "info" | "warn"
-export type AudioLayer = "bgm" | "ambience" | "sfx"
-export type AudioAction = "play" | "stop" | "pause" | "resume" | "volume"
-export type AdminErrorCode =
-  | "forbidden"
-  | "unknown_provider"
-  | "bad_request"
-  | "set_failed"
-  | "not_found"
-  | "op_failed"
-  | "not_configured"
-export type AdminRoomOpAction = "export" | "import" | "delete" | "reset"
-export type AdminForgeKind = "skill" | "rule" | "module"
+export const PLAYER_ROLES = ["player", "keeper"] as const
+export type PlayerRole = (typeof PLAYER_ROLES)[number]
+export const ADMIN_KEY_PURPOSES = ["join", "chat_bind"] as const
+export type AdminKeyPurpose = (typeof ADMIN_KEY_PURPOSES)[number]
+export const NARRATIVE_SPEAKERS = ["kp", "player", "system", "npc"] as const
+export type NarrativeSpeaker = (typeof NARRATIVE_SPEAKERS)[number]
+export const NARRATIVE_FORMATS = ["markdown", "plain"] as const
+export type NarrativeFormat = (typeof NARRATIVE_FORMATS)[number]
+
+/** Every `error.code` the current protocol emits. Derived union so a new code
+ * cannot land in types without also joining the runtime set the architecture
+ * gate cross-checks against locales and `net.session.ERROR_CODES`. */
+export const ERROR_CODES = [
+  "bad_key",
+  "bad_frame",
+  "input_too_long",
+  "rate_limited",
+  "server_error",
+  "join_timeout",
+  "too_many_connections",
+  "demo_unavailable",
+  "forbidden",
+  "media_disabled",
+  "media_rate_limited",
+  "media_bad_mime",
+  "media_too_large",
+  "media_quota_exceeded",
+  "media_bad_hash",
+  "media_bad_offer",
+  "media_bad_svg",
+  "media_bad_upload",
+  "media_size_mismatch",
+  "media_hash_mismatch",
+  "media_not_found",
+  "avatar_no_character",
+] as const
+export type ErrorCode = (typeof ERROR_CODES)[number]
+
+export const DICE_KINDS = ["roll", "check", "subsystem", "opposed", "init"] as const
+export type DiceKind = (typeof DICE_KINDS)[number]
+export const SYSTEM_LEVELS = ["info", "warn"] as const
+export type SystemLevel = (typeof SYSTEM_LEVELS)[number]
+export const AUDIO_LAYERS = ["bgm", "ambience", "sfx"] as const
+export type AudioLayer = (typeof AUDIO_LAYERS)[number]
+export const AUDIO_ACTIONS = ["play", "stop", "pause", "resume", "volume"] as const
+export type AudioAction = (typeof AUDIO_ACTIONS)[number]
+
+/** Every `admin_error.code` the current protocol emits. Same derived-union
+ * contract as `ERROR_CODES`. */
+export const ADMIN_ERROR_CODES = [
+  "forbidden",
+  "unknown_provider",
+  "bad_request",
+  "set_failed",
+  "not_found",
+  "op_failed",
+  "not_configured",
+  "last_keeper",
+] as const
+export type AdminErrorCode = (typeof ADMIN_ERROR_CODES)[number]
+
+export const ADMIN_ROOM_OP_ACTIONS = ["export", "import", "delete", "reset"] as const
+export type AdminRoomOpAction = (typeof ADMIN_ROOM_OP_ACTIONS)[number]
+export const ADMIN_FORGE_KINDS = ["skill", "rule", "module"] as const
+export type AdminForgeKind = (typeof ADMIN_FORGE_KINDS)[number]
 
 export interface ClientInfo {
   name: string
@@ -188,7 +213,7 @@ export interface PackCardEntry {
    * imports through the KEEPER's `.import <ref> world`; a `character` card is the
    * ordinary `.import <ref> pc`. Absent from a pre-2.3 server — treat that as
    * `"character"`, which is what every client assumed before this field existed. */
-  kind?: "character" | "world"
+  kind?: PackCardKind
 }
 
 // v2.2: the unicast answer to `list_pack_cards`. `cards` is empty (not absent)
@@ -341,9 +366,26 @@ export interface DiceFrame {
 // block before it reaches the wire, so clients may render them as-is. Content is
 // player-visible authorial output — the same trust stance as narration.
 
-export type UiPanel = "inline" | "sidebar"
-export type UiBadgeTone = "info" | "warn" | "danger"
-export type UiTextStyle = "quote" | "warning"
+export const UI_PANELS = ["inline", "sidebar"] as const
+export type UiPanel = (typeof UI_PANELS)[number]
+export const UI_BADGE_TONES = ["info", "warn", "danger"] as const
+export type UiBadgeTone = (typeof UI_BADGE_TONES)[number]
+export const UI_TEXT_STYLES = ["quote", "warning"] as const
+export type UiTextStyle = (typeof UI_TEXT_STYLES)[number]
+export const UI_BLOCK_KINDS = [
+  "meter",
+  "stat",
+  "badge",
+  "text",
+  "divider",
+  "choices",
+  "image",
+  "letter",
+  "clipping",
+  "map_pin",
+  "title_card",
+] as const
+export type UiBlockKind = (typeof UI_BLOCK_KINDS)[number]
 
 export interface UiMeterBlock {
   kind: "meter"
@@ -480,8 +522,14 @@ export interface UiFrame {
 // CLIENT substitutes from its own `state.variables`; tier-2 panels ship sandboxed
 // HTML/JS assets (rich clients) plus a tier-1 `fallback` for everyone else.
 
-export type PanelSlot = "sidebar" | "tray" | "modal"
-export type PanelIntentKind = "choice" | "input" | "roll"
+export const PANEL_SLOTS = ["sidebar", "tray", "modal"] as const
+export type PanelSlot = (typeof PANEL_SLOTS)[number]
+export const PANEL_INTENT_KINDS = ["choice", "input", "roll"] as const
+export type PanelIntentKind = (typeof PANEL_INTENT_KINDS)[number]
+export const PANEL_LEAF_FIELDS = ["id", "label", "value"] as const
+export type PanelLeafField = (typeof PANEL_LEAF_FIELDS)[number]
+export const PACK_CARD_KINDS = ["character", "world"] as const
+export type PackCardKind = (typeof PACK_CARD_KINDS)[number]
 
 // Localized template text: the server normalizes plain strings to `{en: ...}`.
 export interface PanelText {
@@ -498,7 +546,7 @@ export interface PanelVarBinding {
 
 // `{$leaf: ...}` — inside a `repeat` template only: the matched variable's field.
 export interface PanelLeafBinding {
-  $leaf: "id" | "label" | "value"
+  $leaf: PanelLeafField
 }
 
 export type PanelBindable<T> = T | PanelVarBinding | PanelLeafBinding
@@ -742,7 +790,8 @@ export interface UsageState {
   cache_miss_tokens: number
 }
 
-export type ModuleVariableKind = "number" | "bool" | "text" | "enum"
+export const MODULE_VARIABLE_KINDS = ["number", "bool", "text", "enum"] as const
+export type ModuleVariableKind = (typeof MODULE_VARIABLE_KINDS)[number]
 
 // v1.6 additive: one player-visible module/story variable (a "tracker": suspicion,
 // doom, supplies, ...). Player connections only ever receive player-visible
@@ -829,7 +878,8 @@ export interface SystemFrame {
  * Coarse kind of work a busy turn is doing. Added in 2.3.1 and deliberately closed:
  * the server never puts a tool name or argument on the wire.
  */
-export type TurnActivity = "reading" | "dice" | "cast" | "bookkeeping"
+export const TURN_ACTIVITIES = ["reading", "dice", "cast", "bookkeeping"] as const
+export type TurnActivity = (typeof TURN_ACTIVITIES)[number]
 
 export type TurnStatusFrame =
   | {
@@ -951,7 +1001,8 @@ export interface AdminDeleteRoomDataFrame {
 //  - "chars": also roll new characters (keep the module)
 //  - "all":   erase everything (characters, module, lore, media, story)
 // Room settings (language, house rules) and connections survive every scope.
-export type AdminResetScope = "story" | "chars" | "all"
+export const ADMIN_RESET_SCOPES = ["story", "chars", "all"] as const
+export type AdminResetScope = (typeof ADMIN_RESET_SCOPES)[number]
 
 // In-place campaign restart: wipe part of this room's campaign state while keeping
 // keystore keys and live connections — no backup, no key removal. Contrast

--- a/clients/protocol/src/validate.test.ts
+++ b/clients/protocol/src/validate.test.ts
@@ -1,0 +1,413 @@
+import { describe, expect, test } from "bun:test"
+import { isServerFrame } from "./client"
+import {
+  ADMIN_ERROR_CODES,
+  ERROR_CODES,
+  FrameType,
+  type AdminConfigFrame,
+  type AdminKeysFrame,
+  type AdminModelsFrame,
+  type AdminRulesFrame,
+  type AdminSkillsFrame,
+  type AudioStateFrame,
+  type PackCardsFrame,
+  type PresenceFrame,
+  type StateFrame,
+  type UiManifestFrame,
+  type WelcomeFrame,
+} from "./types"
+
+/**
+ * Engine-shaped positive fixtures. Field sets match what `net.session.welcome_frame`,
+ * `net.state.build_room_state`, `gateway.audio.audio_state_frame`,
+ * `core.panels.wire_panel`, and `net.admin` actually emit — not the shallow
+ * `{type, party:[], …}` stubs the old validator treated as sufficient.
+ */
+const ENGINE_WELCOME: WelcomeFrame = {
+  type: "welcome",
+  protocol: "2.3",
+  features: ["media", "audio"],
+  room: "demo",
+  you: { id: "tui:abc123", name: "Alice", role: "player" },
+  locale: "en",
+  server: "loreweaver",
+  version: "2.3.2",
+}
+
+const ENGINE_STATE: StateFrame = {
+  type: "state",
+  character: {
+    name: "Nora Vance",
+    system: "coc7",
+    resources: [
+      { id: "hp", label: "HP", value: 10, max: 10 },
+      { id: "san", label: "SAN", value: 50, max: 99 },
+      { id: "mp", label: "MP", value: 10, max: 10 },
+    ],
+    attributes: { STR: 50, DEX: 60 },
+    status_effects: [],
+    avatar: { hash: "a".repeat(64), mime: "image/png", size: 12, name: "nora.png" },
+  },
+  party: [
+    {
+      name: "Nora Vance",
+      online: true,
+      active: true,
+      initiative: 12,
+      resources: [{ id: "hp", label: "HP", value: 10, max: 10 }],
+      ai: false,
+    },
+  ],
+  scene: { name: "The Salt & Anchor", focus: "the tide table" },
+  clock: { time: "Night 1, 22:00", round: 2 },
+  initiative: [{ name: "Nora Vance", value: 12, current: true }],
+  online: 1,
+  usage: {
+    context_tokens: 1200,
+    context_window: 8192,
+    input_tokens: 800,
+    output_tokens: 400,
+    cache_hit_tokens: 100,
+    cache_miss_tokens: 700,
+  },
+  variables: [{ id: "suspicion", label: "Suspicion", kind: "number", value: 3, min: 0, max: 10 }],
+  pregens: [{ name: "Mira Vane", claimed_by: "player-1" }],
+  systems: [{ id: "coc7", make_char: "coc" }],
+}
+
+const ENGINE_AUDIO_STATE: AudioStateFrame = {
+  type: "audio_state",
+  layers: [
+    { layer: "ambience", playing: false },
+    { layer: "bgm", playing: true, hash: "b".repeat(64), mime: "audio/mpeg", name: "theme.mp3", volume: 0.7, loop: true },
+    { layer: "sfx", playing: false },
+  ],
+}
+
+const ENGINE_PACK_CARDS: PackCardsFrame = {
+  type: "pack_cards",
+  cards: [
+    { ref: "harbour/cards/pilot.json", pack: "harbour", name: "pilot", kind: "character" },
+    { ref: "harbour/cards/world.json", pack: "harbour", name: "world", kind: "world" },
+  ],
+}
+
+const ENGINE_MANIFEST: UiManifestFrame = {
+  type: "ui_manifest",
+  panels: [
+    {
+      id: "harbour/board",
+      title: { en: "Board" },
+      slot: "sidebar",
+      tier: 1,
+      blocks: [
+        { kind: "meter", label: { en: "Fear" }, value: { $var: "fear" }, min: 0, max: 10 },
+        { kind: "divider" },
+      ],
+    },
+    {
+      id: "harbour/map",
+      title: { en: "Map" },
+      slot: "modal",
+      tier: 2,
+      entry: { hash: "c".repeat(64), size: 128 },
+      assets: [{ path: "app.js", hash: "d".repeat(64), size: 64, mime: "text/javascript" }],
+      fallback: null,
+    },
+  ],
+}
+
+const ENGINE_PRESENCE: PresenceFrame = {
+  type: "presence",
+  players: [{ id: "tui:abc123", name: "Alice", online: true }],
+  online: 1,
+}
+
+const ENGINE_ADMIN_CONFIG: AdminConfigFrame = {
+  type: "admin_config",
+  provider: "openai",
+  chat_model: "gpt-4o",
+  base_url: "",
+  api_key_masked: "",
+  providers: ["openai", "deepseek"],
+  saved_providers: ["openai"],
+  override_active: false,
+}
+
+const ENGINE_ADMIN_MODELS: AdminModelsFrame = {
+  type: "admin_models",
+  provider: "openai",
+  models: ["gpt-4o", "gpt-4o-mini"],
+}
+
+const ENGINE_ADMIN_KEYS: AdminKeysFrame = {
+  type: "admin_keys",
+  keys: [
+    {
+      id: "kid-1",
+      key_masked: "lw-…abc",
+      room: "arkham",
+      name: "Ada",
+      role: "keeper",
+      purpose: "join",
+      expires_at: null,
+    },
+  ],
+}
+
+const ENGINE_ADMIN_SKILLS: AdminSkillsFrame = {
+  type: "admin_skills",
+  skills: [
+    { id: "mature-mode", name: "Mature mode", description: "…", content_rating: "explicit", enabled: false },
+  ],
+}
+
+const ENGINE_ADMIN_RULES: AdminRulesFrame = {
+  type: "admin_rules",
+  systems: [
+    { id: "coc7", built_in: true },
+    { id: "dnd5e", built_in: true },
+  ],
+}
+
+describe("isServerFrame deep validation", () => {
+  test("the reproduced crashers — null entries in load-bearing arrays — drop", () => {
+    expect(isServerFrame({ type: "ui_manifest", panels: [null] })).toBe(false)
+    expect(isServerFrame({ type: "audio_state", layers: [null] })).toBe(false)
+    expect(isServerFrame({ type: "state", party: [null], initiative: [], online: 1 })).toBe(false)
+  })
+
+  test("engine-shaped frames of every previously-shallow array pass", () => {
+    for (const frame of [
+      ENGINE_WELCOME,
+      ENGINE_STATE,
+      ENGINE_AUDIO_STATE,
+      ENGINE_PACK_CARDS,
+      ENGINE_MANIFEST,
+      ENGINE_PRESENCE,
+      ENGINE_ADMIN_CONFIG,
+      ENGINE_ADMIN_MODELS,
+      ENGINE_ADMIN_KEYS,
+      ENGINE_ADMIN_SKILLS,
+      ENGINE_ADMIN_RULES,
+    ]) {
+      expect(isServerFrame(frame)).toBe(true)
+    }
+  })
+
+  test("welcome.you requires id/name/role; unknown roles drop", () => {
+    expect(isServerFrame({ ...ENGINE_WELCOME, you: { name: "Alice", role: "player" } })).toBe(false)
+    expect(isServerFrame({ ...ENGINE_WELCOME, you: { id: "p1", name: "Alice", role: "admin" } })).toBe(false)
+    expect(isServerFrame({ ...ENGINE_WELCOME, you: null })).toBe(false)
+    expect(isServerFrame({ ...ENGINE_WELCOME, you: "Alice" })).toBe(false)
+  })
+
+  test("audio_state.layers rejects null, primitives, and missing required fields", () => {
+    const base = { type: FrameType.AudioState }
+    expect(isServerFrame({ ...base, layers: [null] })).toBe(false)
+    expect(isServerFrame({ ...base, layers: ["bgm"] })).toBe(false)
+    expect(isServerFrame({ ...base, layers: [{ playing: true }] })).toBe(false)
+    expect(isServerFrame({ ...base, layers: [{ layer: "voice", playing: true }] })).toBe(false)
+    expect(isServerFrame({ ...base, layers: [{ layer: "bgm" }] })).toBe(false)
+  })
+
+  test("audio_control rejects unknown action/layer so clients cannot index arbitrary keys", () => {
+    expect(isServerFrame({ type: "audio_control", id: "a1", action: "play", layer: "voice" })).toBe(false)
+    expect(isServerFrame({ type: "audio_control", id: "a1", action: "seek", layer: "bgm" })).toBe(false)
+    expect(isServerFrame({ type: "audio_control", id: "a1", action: "play", layer: "bgm" })).toBe(true)
+  })
+
+  test("media / audio refs reject a missing hash/mime/size", () => {
+    const media = {
+      type: "media",
+      id: "m1",
+      hash: "e".repeat(64),
+      mime: "image/png",
+      size: 4,
+      name: "a.png",
+      from: "Ada",
+      ts: 1,
+    }
+    expect(isServerFrame(media)).toBe(true)
+    expect(isServerFrame({ ...media, hash: 1 })).toBe(false)
+    expect(isServerFrame({ type: "media_accept", upload_id: "u1", media: { ...media, type: "media", hash: null } })).toBe(
+      false,
+    )
+    expect(isServerFrame({ type: "media_accept", upload_id: "u1", media: { ...media, type: "media" } })).toBe(true)
+  })
+
+  test("pack_cards.cards rejects null, primitives, and missing ref/pack/name", () => {
+    const base = { type: FrameType.PackCards }
+    expect(isServerFrame({ ...base, cards: [null] })).toBe(false)
+    expect(isServerFrame({ ...base, cards: ["harbour/cards/pilot.json"] })).toBe(false)
+    expect(isServerFrame({ ...base, cards: [{ pack: "harbour", name: "pilot" }] })).toBe(false)
+    expect(isServerFrame({ ...base, cards: [{ ref: "x", pack: "p", name: "n", kind: "npc" }] })).toBe(false)
+    expect(isServerFrame({ ...base, cards: [{ ref: "x", pack: "p", name: "n" }] })).toBe(true)
+  })
+
+  test("ui_manifest.panels rejects null, primitives, and missing id/title/slot/tier", () => {
+    const base = { type: FrameType.UiManifest }
+    expect(isServerFrame({ ...base, panels: [null] })).toBe(false)
+    expect(isServerFrame({ ...base, panels: ["harbour/board"] })).toBe(false)
+    expect(isServerFrame({ ...base, panels: [{ title: { en: "Board" }, slot: "sidebar", tier: 1, blocks: [] }] })).toBe(
+      false,
+    )
+    expect(isServerFrame({ ...base, panels: [{ id: "p", title: "Board", slot: "sidebar", tier: 1 }] })).toBe(false)
+    expect(isServerFrame({ ...base, panels: [{ id: "p", title: { en: "Board" }, slot: "popup", tier: 1 }] })).toBe(
+      false,
+    )
+    expect(isServerFrame({ ...base, panels: [{ id: "p", title: { en: "Board" }, slot: "sidebar", tier: 3 }] })).toBe(
+      false,
+    )
+    expect(isServerFrame({ ...base, panels: [{ id: "p", title: { en: "Board" }, slot: "sidebar", tier: 1, blocks: [null] }] })).toBe(
+      false,
+    )
+    expect(
+      isServerFrame({
+        ...base,
+        panels: [{ id: "p", title: { en: "Board" }, slot: "sidebar", tier: 2, assets: [null] }],
+      }),
+    ).toBe(false)
+  })
+
+  test("a single-level panel repeat with a kind inner block passes", () => {
+    expect(
+      isServerFrame({
+        type: FrameType.UiManifest,
+        panels: [
+          {
+            id: "harbour/clues",
+            title: { en: "Clues" },
+            slot: "sidebar",
+            tier: 1,
+            blocks: [
+              {
+                repeat: {
+                  prefix: "clue.",
+                  block: { kind: "badge", label: { $leaf: "label" } },
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  test("nested and thousand-deep panel repeats drop without walking the tree", () => {
+    const basePanel = { id: "p", title: { en: "Board" }, slot: "sidebar", tier: 1 }
+    const nested = {
+      repeat: {
+        prefix: "outer.",
+        block: { repeat: { prefix: "inner.", block: { kind: "divider" } } },
+      },
+    }
+    expect(
+      isServerFrame({ type: FrameType.UiManifest, panels: [{ ...basePanel, blocks: [nested] }] }),
+    ).toBe(false)
+    expect(
+      isServerFrame({
+        type: FrameType.UiManifest,
+        panels: [{ ...basePanel, tier: 2, fallback: [nested] }],
+      }),
+    ).toBe(false)
+
+    let deep: unknown = { kind: "divider" }
+    for (let i = 0; i < 8000; i++) {
+      deep = { repeat: { prefix: `p${i}.`, block: deep } }
+    }
+    expect(() =>
+      isServerFrame({ type: FrameType.UiManifest, panels: [{ ...basePanel, blocks: [deep] }] }),
+    ).not.toThrow()
+    expect(
+      isServerFrame({ type: FrameType.UiManifest, panels: [{ ...basePanel, blocks: [deep] }] }),
+    ).toBe(false)
+  })
+
+  test("ui / panel blocks: null and primitives drop; unknown kinds pass if they are objects", () => {
+    expect(isServerFrame({ type: "ui", panel: "inline", blocks: [null] })).toBe(false)
+    expect(isServerFrame({ type: "ui", panel: "inline", blocks: ["meter"] })).toBe(false)
+    expect(isServerFrame({ type: "ui", panel: "inline", blocks: [{ kind: "meter", label: "Fear" }] })).toBe(false)
+    expect(isServerFrame({ type: "ui", panel: "inline", blocks: [{ kind: "future_kind", extra: 1 }] })).toBe(true)
+    expect(isServerFrame({ type: "ui", panel: "hud", blocks: [] })).toBe(false)
+  })
+
+  test("state nested arrays reject null, primitives, and missing required fields", () => {
+    const empty: StateFrame = { type: "state", party: [], initiative: [], online: 1 }
+    expect(isServerFrame(empty)).toBe(true)
+    expect(isServerFrame({ ...empty, party: [null] })).toBe(false)
+    expect(isServerFrame({ ...empty, party: ["Nora"] })).toBe(false)
+    expect(isServerFrame({ ...empty, party: [{ name: "Nora" }] })).toBe(false)
+    expect(isServerFrame({ ...empty, initiative: [null] })).toBe(false)
+    expect(isServerFrame({ ...empty, initiative: [{ name: "Nora", value: 12 }] })).toBe(false)
+    expect(isServerFrame({ ...empty, character: { name: "Nora", system: "coc7" } })).toBe(false)
+    expect(
+      isServerFrame({
+        ...empty,
+        character: { name: "Nora", system: "coc7", resources: [null], attributes: {}, status_effects: [] },
+      }),
+    ).toBe(false)
+    expect(isServerFrame({ ...empty, variables: [null] })).toBe(false)
+    expect(isServerFrame({ ...empty, variables: [{ id: "fear", label: "Fear" }] })).toBe(false)
+    expect(isServerFrame({ ...empty, pregens: [null] })).toBe(false)
+    expect(isServerFrame({ ...empty, pregens: [{ name: "Mira" }] })).toBe(false)
+    expect(isServerFrame({ ...empty, systems: [null] })).toBe(false)
+    expect(isServerFrame({ ...empty, systems: [{ make_char: "coc" }] })).toBe(false)
+    expect(isServerFrame({ ...empty, usage: { context_tokens: 1 } })).toBe(false)
+  })
+
+  test("presence.players rejects null, primitives, and missing id/name/online", () => {
+    const base = { type: FrameType.Presence, online: 1 }
+    expect(isServerFrame({ ...base, players: [null] })).toBe(false)
+    expect(isServerFrame({ ...base, players: ["Alice"] })).toBe(false)
+    expect(isServerFrame({ ...base, players: [{ name: "Alice", online: true }] })).toBe(false)
+    expect(isServerFrame({ ...base, players: [{ id: "p1", name: "Alice", online: true }] })).toBe(true)
+  })
+
+  test("admin providers/models/keys/skills/rules arrays reject null and primitives", () => {
+    expect(isServerFrame({ ...ENGINE_ADMIN_CONFIG, providers: [null] })).toBe(false)
+    expect(isServerFrame({ ...ENGINE_ADMIN_CONFIG, providers: [1] })).toBe(false)
+    expect(isServerFrame({ ...ENGINE_ADMIN_MODELS, models: [null] })).toBe(false)
+    expect(isServerFrame({ ...ENGINE_ADMIN_KEYS, keys: [null] })).toBe(false)
+    expect(isServerFrame({ ...ENGINE_ADMIN_KEYS, keys: [{ id: "k1" }] })).toBe(false)
+    expect(isServerFrame({ ...ENGINE_ADMIN_SKILLS, skills: [null] })).toBe(false)
+    expect(isServerFrame({ ...ENGINE_ADMIN_SKILLS, skills: [{ id: "s1" }] })).toBe(false)
+    expect(isServerFrame({ ...ENGINE_ADMIN_RULES, systems: [null] })).toBe(false)
+    expect(isServerFrame({ ...ENGINE_ADMIN_RULES, systems: [{ id: "coc7" }] })).toBe(false)
+  })
+
+  test("closed semantic fields reject values that are not in the current protocol enums", () => {
+    expect(isServerFrame({ type: "narrative", id: "n1", speaker: "chorus", text: "hi", format: "markdown" })).toBe(
+      false,
+    )
+    expect(isServerFrame({ type: "system", level: "error", text: "boom" })).toBe(false)
+    expect(isServerFrame({ type: "dice", actor: "Ada", kind: "luck", expr: "1d6", rolls: [4], total: 4 })).toBe(false)
+    expect(isServerFrame({ type: "admin_room_op", action: "clone", room: "r", keys: 0, store_rows: 0, vector_points: 0 })).toBe(
+      false,
+    )
+    expect(isServerFrame({ type: "admin_generated", kind: "card", ok: true })).toBe(false)
+    expect(
+      isServerFrame({
+        type: "state",
+        party: [],
+        initiative: [],
+        online: 1,
+        variables: [{ id: "x", label: "X", kind: "list", value: "[]" }],
+      }),
+    ).toBe(false)
+  })
+
+  test("unknown extra fields and unknown frame types stay additive", () => {
+    expect(isServerFrame({ ...ENGINE_WELCOME, extra_flag: true, you: { ...ENGINE_WELCOME.you, nickname: "Al" } })).toBe(
+      true,
+    )
+    expect(isServerFrame({ type: "future_additive_frame", value: 1 })).toBe(false)
+    expect(isServerFrame({ type: "ui", panel: "inline", blocks: [{ kind: "spotlight", title: "Act II" }] })).toBe(true)
+  })
+
+  test("ERROR_CODES / ADMIN_ERROR_CODES are non-empty runtime arrays the unions derive from", () => {
+    expect(ERROR_CODES).toContain("demo_unavailable")
+    expect(ADMIN_ERROR_CODES).toContain("last_keeper")
+    expect(ERROR_CODES.length).toBeGreaterThan(10)
+  })
+})

--- a/docs/notes/implemented/deep-protocol-validation.md
+++ b/docs/notes/implemented/deep-protocol-validation.md
@@ -1,0 +1,26 @@
+# Implemented: deep shared-protocol frame validation
+
+- **Problem:** `isServerFrame` treated load-bearing arrays as "is an array" and
+  nested objects as "is an object". `ui_manifest.panels:[null]`,
+  `audio_state.layers:[null]`, and `state.party:[null]` all returned true, so
+  Studio then dereferenced `panel.id` / `wire.layer` / `member.name` and threw.
+  The package README promised malformed frames drop and never crash a consumer.
+  Separately, the runtime and docs already emitted `error.demo_unavailable` and
+  `admin_error.last_keeper` while the TypeScript unions omitted both.
+- **Verdict:** deepen the single validator table in `loreweaver-protocol` so
+  every nested shape a client maps or indexes is an object with its current
+  required fields; closed semantic fields (`action` / `layer` / `role` / `kind`
+  / …) check the protocol enums; export `ERROR_CODES` / `ADMIN_ERROR_CODES`
+  const arrays (unions derive from them) and pin them to the Python frozensets
+  and locale keys with an architecture gate. Patch 2.3.2 — wire `major.minor`
+  stays 2.3.
+- **Reason:** a null in a typed array is not additive future-proofing; it is a
+  crash. Unknown extra fields and unknown frame / block kinds stay ignored, so
+  a newer minor can still talk to this client. `repeat` is the only recursive
+  validator pair; the inner template is checked with `allowRepeat=false` so a
+  nested or thousand-deep repeat tree is a flat reject (protocol: does not
+  nest) and cannot stack-overflow the drop path.
+- **Rule home:** `clients/protocol/src/client.ts` (validator table);
+  `clients/protocol/src/types.ts` (`ERROR_CODES` / `ADMIN_ERROR_CODES`);
+  `tests/architecture/test_protocol_error_codes.py`.
+- **Date:** 2026-08-22.

--- a/net/admin.py
+++ b/net/admin.py
@@ -1112,5 +1112,21 @@ def _generated_frame(kind: str, result: ForgeResult) -> dict[str, Any]:
     }
 
 
+# The codes `_error` actually emits. Cross-checked against the TypeScript
+# `ADMIN_ERROR_CODES` array and the `tui.admin.error.*` locale keys.
+ADMIN_ERROR_CODES: frozenset[str] = frozenset(
+    {
+        "forbidden",
+        "unknown_provider",
+        "bad_request",
+        "set_failed",
+        "not_found",
+        "op_failed",
+        "not_configured",
+        "last_keeper",
+    }
+)
+
+
 def _error(code: str, i18n: I18n) -> dict[str, Any]:
     return {"type": "admin_error", "code": code, "message": i18n.t(f"tui.admin.error.{code}")}

--- a/net/session.py
+++ b/net/session.py
@@ -265,6 +265,38 @@ def parse_frame(raw: Any) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
+# The codes `error_frame` (and MediaError, whose `.code` lands here) actually emit.
+# `tests/architecture/test_protocol_error_codes.py` cross-checks this set against
+# the TypeScript `ERROR_CODES` array and the `tui.error.*` locale keys so a new
+# code cannot ship in one runtime and vanish from the others.
+ERROR_CODES: frozenset[str] = frozenset(
+    {
+        "bad_key",
+        "bad_frame",
+        "input_too_long",
+        "rate_limited",
+        "server_error",
+        "join_timeout",
+        "too_many_connections",
+        "demo_unavailable",
+        "forbidden",
+        "media_disabled",
+        "media_rate_limited",
+        "media_bad_mime",
+        "media_too_large",
+        "media_quota_exceeded",
+        "media_bad_hash",
+        "media_bad_offer",
+        "media_bad_svg",
+        "media_bad_upload",
+        "media_size_mismatch",
+        "media_hash_mismatch",
+        "media_not_found",
+        "avatar_no_character",
+    }
+)
+
+
 def error_frame(code: str, i18n: I18n) -> dict[str, Any]:
     return {"type": "error", "code": code, "message": i18n.t(f"tui.error.{code}")}
 

--- a/tests/architecture/test_protocol_error_codes.py
+++ b/tests/architecture/test_protocol_error_codes.py
@@ -1,0 +1,123 @@
+"""Mechanical gate: wire error codes cannot drift across runtimes.
+
+`error` / `admin_error` codes used to live as a TypeScript union, a pair of
+locale-key prefixes, and a scatter of Python string literals. They DID drift:
+the runtime and docs shipped `demo_unavailable` and `last_keeper` while
+`loreweaver-protocol`'s `ErrorCode` / `AdminErrorCode` omitted them.
+
+This file does not hard-code the expected set. It extracts the three
+authoritative lists — the TS `as const` arrays the unions derive from, the
+Python frozensets next to `error_frame` / `_error`, and the locale keys both
+languages already ship — and fails the build on any mismatch. A new code has
+to land in all three (and both locale files) in the same change.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TYPES_TS = REPO_ROOT / "clients" / "protocol" / "src" / "types.ts"
+SESSION_PY = REPO_ROOT / "net" / "session.py"
+ADMIN_PY = REPO_ROOT / "net" / "admin.py"
+LOCALE_EN = REPO_ROOT / "locales" / "en" / "tui.json"
+LOCALE_ZH = REPO_ROOT / "locales" / "zh" / "tui.json"
+
+def _quoted_strings(body: str) -> frozenset[str]:
+    return frozenset(re.findall(r'"([^"]+)"', body))
+
+
+def _ts_const_array(name: str) -> frozenset[str]:
+    source = TYPES_TS.read_text(encoding="utf-8")
+    match = re.search(
+        rf"export const {re.escape(name)}\s*=\s*\[(.*?)]\s*as const",
+        source,
+        re.DOTALL,
+    )
+    assert match, f"clients/protocol/src/types.ts no longer exports `export const {name} = [...] as const`"
+    values = _quoted_strings(match.group(1))
+    assert values, f"{name} parsed as empty — the extractor no longer matches the array"
+    return values
+
+
+def _py_frozenset(path: Path, name: str) -> frozenset[str]:
+    source = path.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^{re.escape(name)}:\s*frozenset\[str\]\s*=\s*frozenset\(\s*\{{(.*?)\}}\s*\)",
+        source,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert match, f"{path.name} no longer declares `{name}: frozenset[str] = frozenset({{...}})`"
+    values = _quoted_strings(match.group(1))
+    assert values, f"{path.name}::{name} parsed as empty"
+    return values
+
+
+def _locale_codes(path: Path, prefix: str) -> frozenset[str]:
+    catalog = json.loads(path.read_text(encoding="utf-8"))
+    return frozenset(key[len(prefix) :] for key in catalog if key.startswith(prefix))
+
+
+def _literal_call_codes(path: Path, func_names: frozenset[str]) -> frozenset[str]:
+    """String literals passed as the first positional arg to the named calls."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else func.attr if isinstance(func, ast.Attribute) else None
+        if name not in func_names or not node.args:
+            continue
+        arg = node.args[0]
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            found.add(arg.value)
+    return frozenset(found)
+
+
+def test_error_codes_match_across_ts_python_and_both_locales() -> None:
+    ts = _ts_const_array("ERROR_CODES")
+    py = _py_frozenset(SESSION_PY, "ERROR_CODES")
+    en = _locale_codes(LOCALE_EN, "tui.error.")
+    zh = _locale_codes(LOCALE_ZH, "tui.error.")
+    assert ts == py, f"TS ERROR_CODES vs net.session.ERROR_CODES: only-ts={ts - py} only-py={py - ts}"
+    assert ts == en, f"TS ERROR_CODES vs locales/en tui.error.*: only-ts={ts - en} only-en={en - ts}"
+    assert en == zh, f"locales/en vs locales/zh tui.error.*: only-en={en - zh} only-zh={zh - en}"
+
+
+def test_admin_error_codes_match_across_ts_python_and_both_locales() -> None:
+    ts = _ts_const_array("ADMIN_ERROR_CODES")
+    py = _py_frozenset(ADMIN_PY, "ADMIN_ERROR_CODES")
+    en = _locale_codes(LOCALE_EN, "tui.admin.error.")
+    zh = _locale_codes(LOCALE_ZH, "tui.admin.error.")
+    assert ts == py, (
+        f"TS ADMIN_ERROR_CODES vs net.admin.ADMIN_ERROR_CODES: only-ts={ts - py} only-py={py - ts}"
+    )
+    assert ts == en, (
+        f"TS ADMIN_ERROR_CODES vs locales/en tui.admin.error.*: only-ts={ts - en} only-en={en - ts}"
+    )
+    assert en == zh, f"locales/en vs locales/zh tui.admin.error.*: only-en={en - zh} only-zh={zh - en}"
+
+
+def test_error_frame_literals_are_members_of_the_runtime_set() -> None:
+    """A new `error_frame("foo")` / `MediaError("foo")` cannot ship outside the set."""
+    allowed = _py_frozenset(SESSION_PY, "ERROR_CODES")
+    emitted: set[str] = set()
+    for path in (REPO_ROOT / "net").rglob("*.py"):
+        emitted |= _literal_call_codes(path, frozenset({"error_frame", "_error_frame"}))
+    emitted |= _literal_call_codes(REPO_ROOT / "infra" / "media_store.py", frozenset({"MediaError"}))
+    unknown = frozenset(emitted) - allowed
+    assert not unknown, f"runtime emits error codes missing from ERROR_CODES: {sorted(unknown)}"
+
+
+def test_admin_error_literals_are_members_of_the_runtime_set() -> None:
+    allowed = _py_frozenset(ADMIN_PY, "ADMIN_ERROR_CODES")
+    emitted = _literal_call_codes(ADMIN_PY, frozenset({"_error", "_last_keeper_error"}))
+    # `_last_keeper_error` has no code literal; `_error("last_keeper")` does.
+    unknown = emitted - allowed
+    assert not unknown, f"runtime emits admin_error codes missing from ADMIN_ERROR_CODES: {sorted(unknown)}"
+    assert "last_keeper" in allowed
+    assert "demo_unavailable" in _py_frozenset(SESSION_PY, "ERROR_CODES")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- deeply validate load-bearing nested server frame shapes before dispatch
- reject malformed known shapes while preserving additive unknown fields/kinds
- prevent nested-repeat validator recursion
- synchronize TypeScript/Python/locale error-code sets
- release protocol package patch 2.3.2; wire remains 2.3

## Tests
- full backend pytest, Ruff, and i18n
- protocol package and TUI tests/build
- combined all-PR integration suite

## Adoption
Studio remains on published 2.3.1 until this package is published as 2.3.2.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8df0c996-410d-4440-a105-824b093328bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8df0c996-410d-4440-a105-824b093328bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

