### PR TITLE
fix(iroh): await transport shutdown

### DIFF
--- a/docs/defensive-patterns.md
+++ b/docs/defensive-patterns.md
@@ -51,3 +51,14 @@ names where it bit us; the fix commit is the proof it was paid for.
    else. Read the vendor's own definition before treating any of them as a
    size signal — and remember that a truncated reply arrives as a SUCCESS, so
    nothing downstream will flag it for you.
+7. **Cancel is not cleanup, and a native `close()` is often awaitable.**
+   `IrohServer.close` used to `task.cancel()` without awaiting the children and
+   called `endpoint.close()` without `await`. The real iroh `Endpoint.close()`
+   is async (`accept_next` returns `None` only after that await), so the
+   accept loop stayed live and the process logged
+   `RuntimeWarning: coroutine Endpoint.close was never awaited`. Snapshot the
+   tracked-task set first (done callbacks mutate it), cancel, drain
+   `CancelledError`, then `await` the endpoint close. The same class of miss:
+   do not fold `asyncio.TimeoutError` into a silent `except Exception` on a
+   documented handshake — the protocol promises `error{code:'join_timeout'}`,
+   and swallowing it makes clients redial a half-alive QUIC connection.

--- a/docs/defensive-patterns.md
+++ b/docs/defensive-patterns.md
@@ -51,14 +51,3 @@ names where it bit us; the fix commit is the proof it was paid for.
    else. Read the vendor's own definition before treating any of them as a
    size signal — and remember that a truncated reply arrives as a SUCCESS, so
    nothing downstream will flag it for you.
-7. **Cancel is not cleanup, and a native `close()` is often awaitable.**
-   `IrohServer.close` used to `task.cancel()` without awaiting the children and
-   called `endpoint.close()` without `await`. The real iroh `Endpoint.close()`
-   is async (`accept_next` returns `None` only after that await), so the
-   accept loop stayed live and the process logged
-   `RuntimeWarning: coroutine Endpoint.close was never awaited`. Snapshot the
-   tracked-task set first (done callbacks mutate it), cancel, drain
-   `CancelledError`, then `await` the endpoint close. The same class of miss:
-   do not fold `asyncio.TimeoutError` into a silent `except Exception` on a
-   documented handshake — the protocol promises `error{code:'join_timeout'}`,
-   and swallowing it makes clients redial a half-alive QUIC connection.

--- a/docs/notes/implemented/iroh-lifecycle.md
+++ b/docs/notes/implemented/iroh-lifecycle.md
@@ -1,0 +1,33 @@
+# Implemented: Iroh close drains tasks; join fatals close the QUIC connection
+
+- **Problem:** a real p2p round-trip logged `RuntimeWarning: coroutine
+  Endpoint.close was never awaited`. `IrohServer.close` called the async
+  `endpoint.close()` without awaiting it and cancelled `_tasks` without
+  draining them, so cleanup raced past the function return and `serve()`'s
+  accept loop could not exit. Separately, `_authenticate` swallowed
+  `TimeoutError` as `None`, so the default Iroh carrier never sent the
+  `error{code:'join_timeout'}` that `docs/protocol.md` promises — clients
+  treated it as a drop and redialed. Handshake failures (bad key / bad
+  frame / live-authorization revoke) also left the QUIC connection half-open;
+  WebSocket closes the socket on those paths.
+- **Decision:** `close()` snapshots `_tasks` (done callbacks mutate the set),
+  cancels and `gather`s them (`CancelledError` from children is consumed;
+  other `BaseException`s re-raise), then `await`s `endpoint.close()`, then
+  drains once more for a late `_handle` spawned while accept was still live.
+  The call is idempotent. `_authenticate` distinguishes `asyncio.TimeoutError`
+  (best-effort `join_timeout` then fail), propagates `CancelledError`, and
+  fails cleanly on any other read error. `_handle` always `_close_transport`s
+  the control stream + QUIC connection on exit; `IrohMember.deliver` does the
+  same on revoke, matching `WsMember` + `ws.close()`. Post-join recoverable
+  errors (`rate_limited`, `bad_frame` after join, …) stay on the live stream.
+- **`IrohMember.send_frame` write-failure raise: not in this change.**
+  RoomHub drops a member when `deliver` raises, so making every write failure
+  raise would expand drop policy beyond handshake teardown. WS `_send`
+  already swallows `ConnectionClosed`. Handshake writes go through
+  `_write_line`, which returns `False` on a dead stream so the caller can
+  still close the connection.
+- **Reason:** the documented join fatals have to be distinguishable from a
+  dropped socket, and a default-carrier close has to actually stop accepting.
+- **Rule home:** `docs/defensive-patterns.md` entry 7; `net/iroh_server.py`
+  (`close`, `_authenticate`, `_close_transport`).
+- **Date:** 2026-08-22.

--- a/docs/notes/implemented/iroh-lifecycle.md
+++ b/docs/notes/implemented/iroh-lifecycle.md
@@ -28,6 +28,6 @@
   still close the connection.
 - **Reason:** the documented join fatals have to be distinguishable from a
   dropped socket, and a default-carrier close has to actually stop accepting.
-- **Rule home:** `docs/defensive-patterns.md` entry 7; `net/iroh_server.py`
-  (`close`, `_authenticate`, `_close_transport`).
+- **Rule home:** `net/iroh_server.py` (`close`, `_authenticate`,
+  `_close_transport`).
 - **Date:** 2026-08-22.

--- a/net/iroh_server.py
+++ b/net/iroh_server.py
@@ -18,6 +18,7 @@ listener is actually started.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 from collections.abc import Callable
@@ -102,6 +103,8 @@ class IrohMember:
     session_key: str
     locale: str
     transport: str = "iroh"
+    # QUIC connection; closed on handshake failure and live-authorization revoke (WS `ws.close()`).
+    conn: Any = None
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     authorize: Callable[[], bool] | None = None
     # See `net.tui_server.WsMember.held_events`: live events held during join replay.
@@ -115,7 +118,10 @@ class IrohMember:
             try:
                 await self.send.write_all(line)
             except Exception:
-                pass  # peer gone / stream reset — dropped like a closed socket
+                # Swallow: matches WS `_send`. Raising here would make every hub publish drop
+                # the member (RoomHub drops on `deliver` raise) — a broader policy than this
+                # lifecycle fix. Handshake writes go through `_write_line`, which reports failure.
+                pass
 
     async def deliver(self, event: Event) -> None:
         if self.held_events is not None:
@@ -129,6 +135,7 @@ class IrohMember:
                     "message": get_i18n(self.locale).t("tui.error.forbidden"),
                 }
             )
+            await _close_transport(self.conn, self.send)
             raise PermissionError("member authorization was revoked")  # i18n-exempt: internal hub signal
         frame = render_frame(event)
         if frame is not None:
@@ -192,11 +199,65 @@ def _parse_line(line: bytes) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-async def _write_line(send: Any, frame: dict[str, Any]) -> None:
+async def _await_maybe(value: Any) -> None:
+    if inspect.isawaitable(value):
+        await value
+
+
+async def _write_line(send: Any, frame: dict[str, Any]) -> bool:
+    """Write one newline-JSON frame. Returns False if the stream is gone.
+
+    Handshake uses the return value so it can still close the QUIC connection
+    after a failed write. Post-join media errors stay best-effort (ignore the bool).
+    """
     try:
         await send.write_all((json.dumps(frame, ensure_ascii=False) + "\n").encode("utf-8"))
     except Exception:
-        pass
+        return False
+    return True
+
+
+_FINISH_TIMEOUT = 0.5
+
+
+async def _close_transport(conn: Any, send: Any | None = None) -> None:
+    """Best-effort finish of the control stream, then close the QUIC connection.
+
+    Handshake-failure / live-authorization-revoke / handle-exit only. Post-join
+    recoverable errors (`rate_limited`, `bad_frame` after join, …) stay on the
+    live stream — `docs/protocol.md` closes only on join-handshake fatals.
+
+    Real iroh: `SendStream.finish()` is async; `Connection.close(error_code, reason)`
+    is sync. Fakes may omit args or return an awaitable; both shapes are accepted.
+    `CancelledError` during finish still closes the connection, then re-raises
+    the saved exception (a bare `raise` here is no longer in an active `except`
+    and would become `RuntimeError: No active exception to reraise`).
+    """
+    cancelled_exc: BaseException | None = None
+    if send is not None:
+        finish = getattr(send, "finish", None)
+        if finish is not None:
+            try:
+                await asyncio.wait_for(_await_maybe(finish()), timeout=_FINISH_TIMEOUT)
+            except asyncio.CancelledError as exc:
+                cancelled_exc = exc
+            except Exception:
+                pass
+    if conn is not None:
+        closer = getattr(conn, "close", None)
+        if closer is not None:
+            try:
+                try:
+                    result = closer(0, b"")
+                except TypeError:
+                    result = closer()
+                await _await_maybe(result)
+            except asyncio.CancelledError as exc:
+                cancelled_exc = exc
+            except Exception:
+                pass
+    if cancelled_exc is not None:
+        raise cancelled_exc
 
 
 async def _write_bytes_chunked(send: Any, data: bytes, chunk_size: int = _READ_CHUNK) -> None:
@@ -246,8 +307,13 @@ class IrohServer:
         """Accept connections until the endpoint is closed (call `start()` first)."""
         assert self._endpoint is not None, "call start() before serve()"
         while True:
+            endpoint = self._endpoint
+            if endpoint is None:
+                break
             try:
-                incoming = await self._endpoint.accept_next()
+                incoming = await endpoint.accept_next()
+            except asyncio.CancelledError:
+                raise
             except Exception:
                 break
             if incoming is None:
@@ -258,46 +324,57 @@ class IrohServer:
 
     async def _handle(self, incoming: Any) -> None:
         core = self.core
+        conn: Any = None
+        send: Any = None
         try:
-            accepting = await incoming.accept()
-            conn = await accepting.connect()
-            bi = await conn.accept_bi()
-        except Exception:
-            return
-        send = bi.send()
-        reader = _LineReader(bi.recv())
-
-        member = await self._authenticate(reader, send)
-        if member is None:
-            return
-        if not core._refresh_member_authorization(member):
-            await member.send_frame(
-                {
-                    "type": "error",
-                    "code": "forbidden",
-                    "message": get_i18n(member.locale).t("tui.error.forbidden"),
-                }
-            )
-            return
-        await core.hub.subscribe(member.session_key, member)
-        media_task = asyncio.create_task(self._accept_media_streams(conn, member))
-        try:
-            await core._replay_history(member)
-            await publish_state(core.hub, core.services, core._ctx_for(member))
-            await core.send_ui_manifest(member)
-            while True:
-                line = await reader.readline()
-                if line is None:
-                    break
-                await core._on_frame(member, line)
-        finally:
-            media_task.cancel()
             try:
-                await media_task
+                accepting = await incoming.accept()
+                conn = await accepting.connect()
+                bi = await conn.accept_bi()
             except asyncio.CancelledError:
-                pass
-            core.drop_pending_media(member)
-            await core.hub.unsubscribe(member)
+                raise
+            except Exception:
+                return
+            send = bi.send()
+            reader = _LineReader(bi.recv())
+
+            member = await self._authenticate(reader, send)
+            if member is None:
+                return
+            member.conn = conn
+            if not core._refresh_member_authorization(member):
+                await member.send_frame(
+                    {
+                        "type": "error",
+                        "code": "forbidden",
+                        "message": get_i18n(member.locale).t("tui.error.forbidden"),
+                    }
+                )
+                return
+            await core.hub.subscribe(member.session_key, member)
+            media_task = asyncio.create_task(self._accept_media_streams(conn, member))
+            try:
+                await core._replay_history(member)
+                await publish_state(core.hub, core.services, core._ctx_for(member))
+                await core.send_ui_manifest(member)
+                while True:
+                    line = await reader.readline()
+                    if line is None:
+                        break
+                    await core._on_frame(member, line)
+            finally:
+                media_task.cancel()
+                try:
+                    await media_task
+                except asyncio.CancelledError:
+                    pass
+                core.drop_pending_media(member)
+                await core.hub.unsubscribe(member)
+        finally:
+            # Always tear down the QUIC connection when this handler exits: handshake
+            # failure, EOF, cancellation, or live-auth revoke. Post-join recoverable
+            # errors stay on the stream and do not come through this path.
+            await _close_transport(conn, send)
 
     async def _accept_media_streams(self, conn: Any, member: IrohMember) -> None:
         while True:
@@ -347,11 +424,25 @@ class IrohServer:
 
     async def _authenticate(self, reader: _LineReader, send: Any) -> IrohMember | None:
         """Consume the mandatory first `join` line; `welcome` + return an `IrohMember` on
-        success, best-effort `error` + drop on failure. Mirrors the WS _authenticate."""
+        success, best-effort `error` + drop on failure. Mirrors the WS _authenticate.
+
+        `TimeoutError` (`asyncio.wait_for`; `asyncio.TimeoutError` is this alias)
+        writes the promised `error{code:'join_timeout'}` then fails. `CancelledError`
+        propagates (server shutdown). Other read errors fail cleanly with no frame —
+        the caller closes the QUIC connection. A failed `welcome` write (`_write_line`
+        returns False) also returns None so `_handle` never subscribes a half-open member.
+        """
         i18n = get_i18n(self.core.services.settings.locale)
         timeout = getattr(self.core, "join_timeout", _DEFAULT_JOIN_TIMEOUT) or _DEFAULT_JOIN_TIMEOUT
         try:
             line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+        except TimeoutError:
+            await _write_line(
+                send, {"type": "error", "code": "join_timeout", "message": i18n.t("tui.error.join_timeout")}
+            )
+            return None
+        except asyncio.CancelledError:
+            raise
         except Exception:
             return None
         if line is None:
@@ -370,31 +461,60 @@ class IrohServer:
 
         member = IrohMember(send=send, **fields)
         member.authorize = lambda: self.core._refresh_member_authorization(member)
-        await member.send_frame(
-            welcome_frame(
-                fields,
-                imagegen=self.core.services.imagegen is not None,
-                demo=(
-                    fields["role"] == "keeper"
-                    and await guided_demo_available(self.core.services, fields["session_key"])
-                ),
-                can_update=(
-                    fields["role"] == "keeper"
-                    and bool(self.core.services.settings.tui.update_command)
-                ),
-            )
+        welcome = welcome_frame(
+            fields,
+            imagegen=self.core.services.imagegen is not None,
+            demo=(
+                fields["role"] == "keeper"
+                and await guided_demo_available(self.core.services, fields["session_key"])
+            ),
+            can_update=(
+                fields["role"] == "keeper"
+                and bool(self.core.services.settings.tui.update_command)
+            ),
         )
+        if not await _write_line(send, welcome):
+            return None
         return member
 
-    async def close(self) -> None:
-        """Cancel in-flight per-connection tasks, then close the endpoint. Best-effort and
-        idempotent — safe to call more than once (e.g. once from a signal handler's stop
-        path and once from an outer `finally`)."""
-        for task in list(self._tasks):
+    async def _cancel_and_drain_tasks(self) -> None:
+        """Cancel tracked connection/media tasks and wait for them to settle.
+
+        Snapshot first: each task's done callback discards from `_tasks`, so iterating
+        the live set while awaiting would drop references mid-drain.
+        """
+        tasks = list(self._tasks)
+        if not tasks:
+            return
+        for task in tasks:
             task.cancel()
-        if self._endpoint is not None:
-            endpoint, self._endpoint = self._endpoint, None
-            try:
-                endpoint.close()
-            except Exception:
-                pass
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for result in results:
+            if isinstance(result, asyncio.CancelledError):
+                continue
+            if isinstance(result, BaseException) and not isinstance(result, Exception):
+                raise result
+
+    async def close(self) -> None:
+        """Cancel and drain tracked tasks, then await `endpoint.close()`.
+
+        Idempotent — safe to call more than once (e.g. once from a signal handler's
+        stop path and once from an outer `finally`). `Endpoint.close()` is async and
+        MUST be awaited; a bare call leaves a `RuntimeWarning` and the accept loop
+        stuck. After the endpoint is closed, `serve()`'s `accept_next()` returns
+        `None` and the accept task can exit.
+        """
+        try:
+            await self._cancel_and_drain_tasks()
+        finally:
+            if self._endpoint is not None:
+                endpoint, self._endpoint = self._endpoint, None
+                try:
+                    await _await_maybe(endpoint.close())
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    pass
+            # A late `_handle` can spawn between the first drain and endpoint close
+            # (the accept loop is still live until `endpoint.close()` returns).
+            await self._cancel_and_drain_tasks()

--- a/tests/net/test_iroh_server.py
+++ b/tests/net/test_iroh_server.py
@@ -8,21 +8,29 @@ with fakes — the bug-prone part where a QUIC byte stream is cut back into prot
 `IrohServer.start`), so this always runs.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os
 import stat
+import warnings
+from unittest.mock import AsyncMock
 
 import pytest
 
+from gateway.hub import Event
 from net.iroh_server import (
     IrohMember,
+    IrohServer,
+    _close_transport,
     _LineReader,
     _parse_line,
     _write_bytes_chunked,
     _write_line,
     load_or_create_secret,
 )
+from net.keystore import KeyEntry, Keystore
 
 
 class _FakeRecv:
@@ -36,9 +44,120 @@ class _FakeRecv:
 class _FakeSend:
     def __init__(self) -> None:
         self.written = bytearray()
+        self.finished = False
 
     async def write_all(self, buf: bytes) -> None:
         self.written.extend(buf)
+
+    async def finish(self) -> None:
+        self.finished = True
+
+
+class _FailSend:
+    async def write_all(self, _buf: bytes) -> None:
+        raise ConnectionError("stream reset")
+
+
+class _HangRecv:
+    def __init__(self) -> None:
+        self.entered = asyncio.Event()
+
+    async def read(self, _n: int) -> bytes:
+        self.entered.set()
+        await asyncio.Event().wait()
+        return b""
+
+
+class _FakeBi:
+    def __init__(self, send: _FakeSend, recv: object) -> None:
+        self._send = send
+        self._recv = recv
+
+    def send(self) -> _FakeSend:
+        return self._send
+
+    def recv(self) -> object:
+        return self._recv
+
+
+class _FakeConn:
+    def __init__(self, send: _FakeSend, recv: object) -> None:
+        self._bi = _FakeBi(send, recv)
+        self.close_calls: list[tuple[int, bytes]] = []
+
+    async def accept_bi(self) -> _FakeBi:
+        return self._bi
+
+    def close(self, error_code: int = 0, reason: bytes = b"") -> None:
+        self.close_calls.append((error_code, reason))
+
+
+class _FakeIncoming:
+    def __init__(self, conn: _FakeConn) -> None:
+        self._conn = conn
+
+    async def accept(self) -> _FakeIncoming:
+        return self
+
+    async def connect(self) -> _FakeConn:
+        return self._conn
+
+
+class _FakeTui:
+    update_command = ""
+
+
+class _FakeSettings:
+    locale = "en"
+    tui = _FakeTui()
+
+
+class _FakeServices:
+    settings = _FakeSettings()
+    imagegen = None
+
+
+class _SpyHub:
+    def __init__(self) -> None:
+        self.subscribed = 0
+
+    async def subscribe(self, *_a, **_k) -> None:
+        self.subscribed += 1
+
+
+class _FakeCore:
+    def __init__(self, *, join_timeout: float = 1.0, authorized: bool = True, keys: dict | None = None) -> None:
+        entries = keys if keys is not None else {"good": KeyEntry(key="good", room="room", name="Alice", role="player")}
+        self.keystore = Keystore(entries)
+        self.join_timeout = join_timeout
+        self.services = _FakeServices()
+        self._authorized = authorized
+        self.hub = _SpyHub()
+
+    def _refresh_member_authorization(self, _member) -> bool:
+        return self._authorized
+
+
+def _written_frames(send: _FakeSend) -> list[dict]:
+    raw = bytes(send.written)
+    if not raw:
+        return []
+    return [json.loads(line) for line in raw.split(b"\n") if line]
+
+
+def _member(send: _FakeSend | None = None, **overrides) -> IrohMember:
+    fields = dict(
+        send=send or _FakeSend(),
+        id="i",
+        user_key="u",
+        name="n",
+        role="player",
+        room="r",
+        session_key="s",
+        locale="en",
+    )
+    fields.update(overrides)
+    return IrohMember(**fields)
 
 
 def test_linereader_splits_frames_across_chunk_boundaries() -> None:
@@ -90,13 +209,23 @@ def test_write_line_and_bytes_chunked_for_media_stream() -> None:
     send = _FakeSend()
 
     async def go() -> None:
-        await _write_line(send, {"size": 6})
+        written = await _write_line(send, {"size": 6})
+        assert written is True
         await _write_bytes_chunked(send, b"abcdef", chunk_size=2)
 
     asyncio.run(go())
     line, body = bytes(send.written).split(b"\n", 1)
     assert json.loads(line) == {"size": 6}
     assert body == b"abcdef"
+
+
+def test_write_line_reports_handshake_write_failure() -> None:
+    """The handshake helper must surface a dead stream so the caller can close the QUIC conn."""
+
+    async def go() -> bool:
+        return await _write_line(_FailSend(), {"type": "error", "code": "bad_key"})
+
+    assert asyncio.run(go()) is False
 
 
 # --- persisted secret key (stable NodeId / ticket across restarts) ---------
@@ -251,3 +380,255 @@ def test_serve_iroh_sigterm_triggers_clean_shutdown(monkeypatch, tmp_path) -> No
     result = asyncio.run(go())
     assert result is True  # a clean stop returns True
     assert closed["value"] is True  # the finally-close actually ran
+
+
+# --- lifecycle: close drain + join-handshake fatals (deterministic fakes) ----
+
+
+def test_close_awaits_endpoint_and_settles_cancelled_child_tasks() -> None:
+    """`endpoint.close()` is async and must be awaited AFTER cancelled children settle.
+
+    A bare `endpoint.close()` (the previous bug) leaves `RuntimeWarning: coroutine
+    Endpoint.close was never awaited` and cleanup racing past `close()`'s return.
+    """
+    order: list[str] = []
+    started = asyncio.Event()
+
+    async def child() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await asyncio.sleep(0)
+            order.append("child_settled")
+            raise
+
+    class _FakeEndpoint:
+        async def close(self) -> None:
+            order.append("endpoint_close")
+
+    async def go() -> None:
+        server = IrohServer(object())
+        endpoint = _FakeEndpoint()
+        server._endpoint = endpoint
+        task = asyncio.create_task(child())
+        server._tasks.add(task)
+        task.add_done_callback(server._tasks.discard)
+        await started.wait()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            await server.close()
+        assert task.done()
+        assert task not in server._tasks
+        assert server._endpoint is None
+
+    asyncio.run(go())
+    assert order == ["child_settled", "endpoint_close"]
+
+
+def test_close_twice_is_idempotent_without_warnings() -> None:
+    async def go() -> None:
+        endpoint = AsyncMock()
+        server = IrohServer(object())
+        server._endpoint = endpoint
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            await server.close()
+            await server.close()
+        endpoint.close.assert_awaited_once()
+        assert server._endpoint is None
+
+    asyncio.run(go())
+
+
+def test_close_unblocks_serve_accept_loop() -> None:
+    """After `await endpoint.close()`, `accept_next()` returns None and `serve()` exits."""
+
+    class _FakeEndpoint:
+        def __init__(self) -> None:
+            self.entered = asyncio.Event()
+            self._closed = asyncio.Event()
+            self.close_awaited = False
+
+        async def accept_next(self):
+            self.entered.set()
+            await self._closed.wait()
+            return None
+
+        async def close(self) -> None:
+            self.close_awaited = True
+            self._closed.set()
+
+    async def go() -> None:
+        endpoint = _FakeEndpoint()
+        server = IrohServer(object())
+        server._endpoint = endpoint
+        serve_task = asyncio.create_task(server.serve())
+        await endpoint.entered.wait()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            await server.close()
+        await asyncio.wait_for(serve_task, timeout=1)
+        assert serve_task.done()
+        assert endpoint.close_awaited
+
+    asyncio.run(go())
+
+
+def test_authenticate_timeout_writes_join_timeout() -> None:
+    async def go() -> None:
+        recv = _HangRecv()
+        send = _FakeSend()
+        server = IrohServer(_FakeCore(join_timeout=0.05))
+        member = await server._authenticate(_LineReader(recv), send)
+        assert member is None
+        frames = _written_frames(send)
+        assert frames[0]["type"] == "error"
+        assert frames[0]["code"] == "join_timeout"
+
+    asyncio.run(go())
+
+
+def test_authenticate_propagates_cancellation() -> None:
+    async def go() -> None:
+        recv = _HangRecv()
+        send = _FakeSend()
+        server = IrohServer(_FakeCore(join_timeout=10))
+        task = asyncio.create_task(server._authenticate(_LineReader(recv), send))
+        await recv.entered.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert bytes(send.written) == b""
+
+    asyncio.run(go())
+
+
+def test_authenticate_other_read_error_fails_cleanly() -> None:
+    class _BoomReader:
+        async def readline(self) -> bytes:
+            raise RuntimeError("recv exploded")
+
+    async def go() -> None:
+        send = _FakeSend()
+        server = IrohServer(_FakeCore())
+        member = await server._authenticate(_BoomReader(), send)
+        assert member is None
+        assert bytes(send.written) == b""
+
+    asyncio.run(go())
+
+
+def test_handle_timeout_writes_join_timeout_and_closes_conn() -> None:
+    async def go() -> None:
+        send = _FakeSend()
+        conn = _FakeConn(send, _HangRecv())
+        server = IrohServer(_FakeCore(join_timeout=0.05))
+        await server._handle(_FakeIncoming(conn))
+        frames = _written_frames(send)
+        assert frames[0]["code"] == "join_timeout"
+        assert conn.close_calls
+        assert send.finished
+
+    asyncio.run(go())
+
+
+def test_handle_bad_key_writes_error_and_closes_conn() -> None:
+    async def go() -> None:
+        send = _FakeSend()
+        conn = _FakeConn(send, _FakeRecv([b'{"type":"join","key":"nope"}\n']))
+        server = IrohServer(_FakeCore())
+        await server._handle(_FakeIncoming(conn))
+        frames = _written_frames(send)
+        assert frames[0]["code"] == "bad_key"
+        assert conn.close_calls
+        assert send.finished
+
+    asyncio.run(go())
+
+
+def test_handle_bad_frame_writes_error_and_closes_conn() -> None:
+    async def go() -> None:
+        send = _FakeSend()
+        conn = _FakeConn(send, _FakeRecv([b'{"type":"ping","t":1}\n']))
+        server = IrohServer(_FakeCore())
+        await server._handle(_FakeIncoming(conn))
+        frames = _written_frames(send)
+        assert frames[0]["code"] == "bad_frame"
+        assert conn.close_calls
+        assert send.finished
+
+    asyncio.run(go())
+
+
+def test_handle_live_authorization_failure_closes_conn() -> None:
+    async def go() -> None:
+        send = _FakeSend()
+        conn = _FakeConn(send, _FakeRecv([b'{"type":"join","key":"good"}\n']))
+        server = IrohServer(_FakeCore(authorized=False))
+        await server._handle(_FakeIncoming(conn))
+        frames = _written_frames(send)
+        assert frames[0]["type"] == "welcome"
+        assert frames[1]["code"] == "forbidden"
+        assert conn.close_calls
+        assert send.finished
+
+    asyncio.run(go())
+
+
+def test_deliver_revocation_closes_transport() -> None:
+    async def go() -> None:
+        send = _FakeSend()
+        conn = _FakeConn(send, _FakeRecv([]))
+        member = _member(send, conn=conn)
+        member.authorize = lambda: False
+        with pytest.raises(PermissionError):
+            await member.deliver(Event.system("info", "x"))
+        assert _written_frames(send)[0]["code"] == "forbidden"
+        assert conn.close_calls
+        assert send.finished
+
+    asyncio.run(go())
+
+
+def test_close_transport_cancel_during_finish_closes_conn_and_reraises() -> None:
+    """A cancelled `finish()` must still `conn.close`, then propagate CancelledError
+    — not `RuntimeError: No active exception to reraise` from a bare `raise`."""
+
+    class _HangFinishSend:
+        def __init__(self) -> None:
+            self.entered = asyncio.Event()
+
+        async def finish(self) -> None:
+            self.entered.set()
+            await asyncio.Event().wait()
+
+    async def go() -> None:
+        send = _HangFinishSend()
+        conn = _FakeConn(_FakeSend(), _FakeRecv([]))
+        task = asyncio.create_task(_close_transport(conn, send))
+        await send.entered.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert conn.close_calls
+
+    asyncio.run(go())
+
+
+def test_welcome_write_failure_returns_none_and_does_not_subscribe() -> None:
+    async def go() -> None:
+        core = _FakeCore()
+        server = IrohServer(core)
+        member = await server._authenticate(
+            _LineReader(_FakeRecv([b'{"type":"join","key":"good"}\n'])),
+            _FailSend(),
+        )
+        assert member is None
+
+        conn = _FakeConn(_FailSend(), _FakeRecv([b'{"type":"join","key":"good"}\n']))
+        await server._handle(_FakeIncoming(conn))
+        assert core.hub.subscribed == 0
+        assert conn.close_calls
+
+    asyncio.run(go())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- cancel and drain tracked Iroh connection/media tasks during shutdown
- await asynchronous endpoint close and keep shutdown idempotent
- emit documented fatal `join_timeout` on handshake timeout
- close QUIC transport on handshake/live-authorization failure
- preserve recoverable post-join errors

## Tests
- full backend pytest, Ruff, and i18n
- warnings-as-errors real Iroh live-connect roundtrip
- combined all-PR integration suite
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8df0c996-410d-4440-a105-824b093328bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8df0c996-410d-4440-a105-824b093328bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

