### PR TITLE
fix(auth): recheck keeper access before commit

### DIFF
--- a/agent/kp_tools_charcard.py
+++ b/agent/kp_tools_charcard.py
@@ -395,6 +395,12 @@ class CharcardTools:
 
             card, lorecard = _parse_any_card_file(host_path)
             character, world = split_card(card)
+            # Parse / split is the long prep; import_entries is the first write.
+            # Last reauth success here is the linearization point for the batch.
+            from infra.live_auth import ctx_still_authorized
+
+            if not await ctx_still_authorized(ctx):
+                return _refuse("charcard.commands.import.world_denied")
             # Keeper trust: secrecy flags are honored and InitVar declarations are consumed
             # into the shared MVU tree (`core.worldbook.import_entries` gates that on
             # `is_keeper=True`). The ORIGINAL entries are imported, not the stripped half —

--- a/agent/kp_tools_knowledge.py
+++ b/agent/kp_tools_knowledge.py
@@ -944,6 +944,12 @@ class DocumentTools(_KnowledgeToolsBase):
             chat_key = ctx.chat_key
             await _emit(progress, "read", str(len(text_content)))
             await _emit(progress, "embed")
+            # Progress emit is preflight (it may await). Last reauth success
+            # immediately before store_document is the linearization point.
+            from infra.live_auth import ctx_still_authorized
+
+            if not await ctx_still_authorized(ctx):
+                return i18n.t("rooms.denied")
             chunk_count = await self._services.vector_db.store_document(
                 document_id=str(uuid.uuid4()),
                 filename=filename,

--- a/docs/defensive-patterns.md
+++ b/docs/defensive-patterns.md
@@ -51,17 +51,3 @@ names where it bit us; the fix commit is the proof it was paid for.
    else. Read the vendor's own definition before treating any of them as a
    size signal — and remember that a truncated reply arrives as a SUCCESS, so
    nothing downstream will flag it for you.
-7. **Live-reauth at the commit boundary, not only at the lock.** The
-   transport choke point refreshes a keeper key when it takes the room lock,
-   but another admin connection or ops process can revoke or demote that key
-   during verification, backup, or analysis. Long / destructive keeper ops
-   (`.undo`, `.save` / `.save load`, world/module import, admin
-   export/import/delete/reset and key/room delete) re-check authorization
-   AFTER that preflight and BEFORE the first irreversible mutation or the
-   final secret-artifact write. The last successful reauth is the
-   linearization point: the operation is authorized. Do not try to kill a
-   transaction that has already begun. Fail closed — no backup created or
-   overwritten, no storage/key/vector/media change, existing
-   forbidden/denied copy, no path or content leak. Rule home:
-   `infra.live_auth.confirm_live_authorization`;
-   `docs/notes/implemented/live-reauth-at-commit-boundary.md`.

--- a/docs/defensive-patterns.md
+++ b/docs/defensive-patterns.md
@@ -51,3 +51,17 @@ names where it bit us; the fix commit is the proof it was paid for.
    else. Read the vendor's own definition before treating any of them as a
    size signal — and remember that a truncated reply arrives as a SUCCESS, so
    nothing downstream will flag it for you.
+7. **Live-reauth at the commit boundary, not only at the lock.** The
+   transport choke point refreshes a keeper key when it takes the room lock,
+   but another admin connection or ops process can revoke or demote that key
+   during verification, backup, or analysis. Long / destructive keeper ops
+   (`.undo`, `.save` / `.save load`, world/module import, admin
+   export/import/delete/reset and key/room delete) re-check authorization
+   AFTER that preflight and BEFORE the first irreversible mutation or the
+   final secret-artifact write. The last successful reauth is the
+   linearization point: the operation is authorized. Do not try to kill a
+   transaction that has already begun. Fail closed — no backup created or
+   overwritten, no storage/key/vector/media change, existing
+   forbidden/denied copy, no path or content leak. Rule home:
+   `infra.live_auth.confirm_live_authorization`;
+   `docs/notes/implemented/live-reauth-at-commit-boundary.md`.

--- a/docs/notes/implemented/live-reauth-at-commit-boundary.md
+++ b/docs/notes/implemented/live-reauth-at-commit-boundary.md
@@ -1,0 +1,30 @@
+# Implemented: live reauth at the commit boundary
+
+- **Problem:** long or destructive Keeper operations refresh authorization
+  when the transport choke point takes the room lock, but another admin
+  connection or ops process can revoke or demote that key during
+  verification, backup, or analysis. Without a second check at the real
+  mutation, a revoked connection could still `.undo`, `.save load`, import,
+  or delete.
+- **Verdict:** re-check live authorization after the expensive preflight and
+  immediately before the first irreversible mutation or the final
+  secret-artifact write. The last successful reauth is the linearization
+  point — the operation is authorized. Do not try to kill a transaction
+  that has already begun. Fail closed: no backup created or overwritten, no
+  storage / key / vector / media change, existing forbidden / denied copy,
+  no path or content leak. Ordinary short commands stay a single gate.
+- **Reason:** the lock-time refresh is necessary and not sufficient. The
+  window that matters is preflight → commit, and only the commit-boundary
+  check closes it. `AdminService.reauthorize` and `_keeper_still_authorized`
+  were already the model (config lock, `.reset`); the room-backup API now
+  carries the same optional callback to the write that actually counts. The
+  helper accepts a sync or awaitable callback so a future I/O refresh does
+  not force a second shape.
+- **Rule home:** `docs/defensive-patterns.md` entry 7;
+  `infra.live_auth` (the exception + sync/awaitable helper);
+  `net.room_backup` commit calls (export write, import first store mutation,
+  delete first store mutation, reset first hook);
+  `gateway.commands.rooms._keeper_still_authorized` (`.undo` before
+  reset/restore; tui/iroh fail closed without a callback);
+  world/module import immediately before the first write after parse/progress.
+- **Date:** 2026-08-22.

--- a/docs/notes/implemented/live-reauth-at-commit-boundary.md
+++ b/docs/notes/implemented/live-reauth-at-commit-boundary.md
@@ -20,8 +20,7 @@
   carries the same optional callback to the write that actually counts. The
   helper accepts a sync or awaitable callback so a future I/O refresh does
   not force a second shape.
-- **Rule home:** `docs/defensive-patterns.md` entry 7;
-  `infra.live_auth` (the exception + sync/awaitable helper);
+- **Rule home:** `infra/live_auth.py` (the exception + sync/awaitable helper);
   `net.room_backup` commit calls (export write, import first store mutation,
   delete first store mutation, reset first hook);
   `gateway.commands.rooms._keeper_still_authorized` (`.undo` before

--- a/gateway/commands/rooms.py
+++ b/gateway/commands/rooms.py
@@ -28,6 +28,7 @@ from gateway.rooms import (
     set_keeper_binding,
 )
 from gateway.turn import publish_state
+from infra.live_auth import AuthorizationRevoked, invoke_reauthorize
 from infra.room_facets import RESET_SCOPES, STORAGE_ROOM_STATE, RoomStateFacet
 
 logger = logging.getLogger(__name__)
@@ -146,6 +147,15 @@ def _is_keeper(ctx: Any) -> bool:
     return isinstance(extra, dict) and extra.get("role") == _TUI_KEEPER_ROLE
 
 
+def _command_reauthorize(ctx: CommandCtx) -> Any:
+    """Live-authorization callback for a command's room_backup commit boundary."""
+
+    async def _check() -> bool:
+        return await _keeper_still_authorized(ctx.raw_ctx, ctx.chat_key, ctx.services.store)
+
+    return _check
+
+
 async def _keeper_still_authorized(ctx: Any, chat_key: str, store: Any) -> bool:
     platform = str(getattr(ctx, "platform", "") or "").casefold()
     if platform in _AUTO_MASTER_PLATFORMS:
@@ -156,7 +166,9 @@ async def _keeper_still_authorized(ctx: Any, chat_key: str, store: Any) -> bool:
     if source is None or platform in {"tui", "iroh"}:
         extra = getattr(ctx, "extra", None)
         reauthorize = extra.get("reauthorize") if isinstance(extra, dict) else None
-        return bool(reauthorize()) if callable(reauthorize) else True
+        # Network transports must present a live callback. A stamped keeper role
+        # without one is fail-closed — the key may already have been revoked.
+        return await invoke_reauthorize(reauthorize, missing_ok=False)
     room = await get_keeper_binding(
         store,
         source.platform,
@@ -293,10 +305,22 @@ class RoomsCommands:
         # dispatch already — re-acquiring `hub.turn_lock` HERE wedged the room forever:
         # the lock is not reentrant and its holder was this very task, so the second
         # acquire waited on itself and every later turn queued behind it.
+        # Availability / snapshot lookup is the preflight; reset/restore is the mutation.
+        # Last reauth success here is the linearization point.
+        if not await _keeper_still_authorized(ctx.raw_ctx, ctx.chat_key, ctx.services.store):
+            return ctx.fail(ctx.i18n.t("commands.undo.denied"))
         if target == 0:
             from net.room_backup import reset_room_state
 
-            await reset_room_state(ctx.services, ctx.chat_key, scope="story")
+            try:
+                await reset_room_state(
+                    ctx.services,
+                    ctx.chat_key,
+                    scope="story",
+                    reauthorize=_command_reauthorize(ctx),
+                )
+            except AuthorizationRevoked:
+                return ctx.fail(ctx.i18n.t("commands.undo.denied"))
         elif not await restore_room(ctx.services, ctx.chat_key, target):
             return ctx.i18n.t("commands.undo.unavailable", turns="-")
         await ctx.services.store.state_set(ctx.chat_key, CHRONICLE_TURN_KEY, str(target))
@@ -349,6 +373,7 @@ class RoomsCommands:
         sub = parts[0].casefold() if parts else ""
         rest = parts[1].strip() if len(parts) > 1 else ""
         room = room_for_chat_key(ctx.chat_key)
+        reauthorize = _command_reauthorize(ctx)
         try:
             if sub in _SAVE_LOAD_WORDS:
                 if not rest:
@@ -356,11 +381,17 @@ class RoomsCommands:
                 # Serialized by the transport choke point's turn lock, exactly like
                 # `.undo` above — a command handler must never re-take the room's own
                 # lock (not reentrant; the holder is this task).
-                result = await import_room(ctx.services, keystore, rest, expected_room=room)
+                result = await import_room(
+                    ctx.services, keystore, rest, expected_room=room, reauthorize=reauthorize
+                )
                 await self._publish_reset(ctx)
                 return ctx.i18n.t("commands.save.loaded", name=rest, documents=result.get("documents", 0))
-            result = await export_room(ctx.services, keystore, room, ctx.args.strip())
+            result = await export_room(
+                ctx.services, keystore, room, ctx.args.strip(), reauthorize=reauthorize
+            )
             return ctx.i18n.t("commands.save.done", path=str(result.get("path", "")))
+        except AuthorizationRevoked:
+            return ctx.fail(ctx.i18n.t("commands.save.denied"))
         except Exception as exc:  # noqa: BLE001 — a save must report, never crash the room
             logger.warning("room save/load failed for %s", ctx.chat_key, exc_info=True)
             return ctx.i18n.t("commands.save.failed", error=str(exc))
@@ -527,8 +558,14 @@ class RoomsCommands:
 
                 try:
                     result = await reset_room_state(
-                        ctx.services, ctx.chat_key, scope=armed_scope, keystore=self.keystore
+                        ctx.services,
+                        ctx.chat_key,
+                        scope=armed_scope,
+                        keystore=self.keystore,
+                        reauthorize=_command_reauthorize(ctx),
                     )
+                except AuthorizationRevoked:
+                    return ctx.fail(ctx.i18n.t("commands.reset.denied"))
                 except Exception:
                     logger.exception("campaign reset failed for %s", ctx.chat_key)
                     return ctx.i18n.t("commands.reset.failed")

--- a/infra/live_auth.py
+++ b/infra/live_auth.py
@@ -1,0 +1,71 @@
+"""Live authorization at a commit boundary.
+
+Long or destructive keeper ops re-check after preflight and immediately
+before the first irreversible write. The last successful reauth is the
+linearization point. Fail closed: a missing callback is allowed only when
+the caller opts in (CLI auto-master, internal room_backup ``None``).
+Network transports (``tui`` / ``iroh``) must supply a live callback.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+NETWORK_LIVE_AUTH_PLATFORMS = frozenset({"tui", "iroh"})
+
+
+class AuthorizationRevoked(Exception):
+    """Live authorization failed at a commit boundary.
+
+    The last successful reauth is the linearization point: callers must fail
+    closed (no backup created or overwritten, no storage/key/vector/media
+    change) and map this to the existing forbidden/denied copy. The message is
+    empty on purpose so a leaky ``str(exc)`` cannot reveal a path or snapshot.
+    """
+
+
+def missing_ok_for_platform(platform: str) -> bool:
+    """True when a missing callback may pass (CLI / unspecified local)."""
+    return str(platform or "").casefold() not in NETWORK_LIVE_AUTH_PLATFORMS
+
+
+async def invoke_reauthorize(reauthorize: Any, *, missing_ok: bool = True) -> bool:
+    """Run an optional live-authorization callback (sync or awaitable).
+
+    ``None`` means the caller does not require a live check when ``missing_ok``.
+    A non-callable callback, a raising callback, or a falsey result fail closed.
+    The callback is sync on the current transports; awaiting a future result
+    keeps the helper honest if a refresh ever becomes I/O.
+    """
+    if reauthorize is None:
+        return missing_ok
+    if not callable(reauthorize):
+        return False
+    try:
+        result = reauthorize()
+        if inspect.isawaitable(result):
+            result = await result
+    except Exception:
+        return False
+    return bool(result)
+
+
+async def confirm_live_authorization(reauthorize: Any) -> None:
+    """Raise ``AuthorizationRevoked`` unless the optional callback still grants access.
+
+    A missing callback is allowed here: room_backup and other internal callers
+    pass ``None`` when no live check is required.
+    """
+    if not await invoke_reauthorize(reauthorize, missing_ok=True):
+        raise AuthorizationRevoked()
+
+
+async def ctx_still_authorized(ctx: Any) -> bool:
+    """Live-check ``ctx.extra['reauthorize']``, fail-closed on network platforms."""
+    extra = getattr(ctx, "extra", None)
+    reauthorize = extra.get("reauthorize") if isinstance(extra, dict) else None
+    return await invoke_reauthorize(
+        reauthorize,
+        missing_ok=missing_ok_for_platform(getattr(ctx, "platform", "")),
+    )

--- a/net/admin.py
+++ b/net/admin.py
@@ -47,6 +47,11 @@ from infra.imagegen import (
     build_imagegen,
     describe_imagegen_settings,
 )
+from infra.live_auth import (
+    AuthorizationRevoked,
+    confirm_live_authorization,
+    invoke_reauthorize,
+)
 from infra.oauth_flows import (
     SUBSCRIPTION_DEFAULT_MODELS,
     canonical_subscription_provider,
@@ -133,6 +138,10 @@ class AdminService:
         if role == _KEEPER_ROLE and frame.get("type") == "admin_delete_key":
             binding = await self._chat_binding_for_id(caller_room, str(frame.get("id") or ""))
             if binding is not None:
+                try:
+                    await confirm_live_authorization(reauthorize)
+                except AuthorizationRevoked:
+                    return await self._with_chat_bindings(_error("forbidden", i18n), caller_room)
                 await clear_keeper_binding(
                     self.services.store,
                     *binding,
@@ -261,12 +270,12 @@ async def _dispatch_admin_frame(
         return await _config_frame(services)
     if kind == "admin_set_model":
         async with services.config_lock:
-            if reauthorize is not None and not reauthorize():
+            if not await invoke_reauthorize(reauthorize):
                 return _error("forbidden", i18n)
             return await _set_model(services, frame, i18n)
     if kind == "admin_set_imagegen":
         async with services.config_lock:
-            if reauthorize is not None and not reauthorize():
+            if not await invoke_reauthorize(reauthorize):
                 return _error("forbidden", i18n)
             return await _set_imagegen(services, frame, i18n)
     if kind == "admin_list_models":
@@ -276,19 +285,29 @@ async def _dispatch_admin_frame(
     if kind == "admin_mint_key":
         return _mint_key(keystore, caller_room, frame, i18n)
     if kind == "admin_update_key":
-        return _update_key(keystore, caller_room, frame, i18n)
+        return await _update_key(keystore, caller_room, frame, i18n, reauthorize=reauthorize)
     if kind == "admin_delete_key":
-        return _delete_key(keystore, caller_room, frame, i18n)
+        return await _delete_key(keystore, caller_room, frame, i18n, reauthorize=reauthorize)
     if kind == "admin_delete_room":
-        return await _delete_room(services, keystore, caller_room, frame, i18n)
+        return await _delete_room(
+            services, keystore, caller_room, frame, i18n, reauthorize=reauthorize
+        )
     if kind == "admin_export_room":
-        return await _export_room(services, keystore, caller_room, frame, i18n)
+        return await _export_room(
+            services, keystore, caller_room, frame, i18n, reauthorize=reauthorize
+        )
     if kind == "admin_import_room":
-        return await _import_room(services, keystore, caller_room, frame, i18n)
+        return await _import_room(
+            services, keystore, caller_room, frame, i18n, reauthorize=reauthorize
+        )
     if kind == "admin_delete_room_data":
-        return await _delete_room_data(services, keystore, caller_room, frame, i18n, hub=hub)
+        return await _delete_room_data(
+            services, keystore, caller_room, frame, i18n, hub=hub, reauthorize=reauthorize
+        )
     if kind == "admin_reset_room":
-        return await _reset_room(services, keystore, caller_room, frame, i18n)
+        return await _reset_room(
+            services, keystore, caller_room, frame, i18n, reauthorize=reauthorize
+        )
     if kind == "admin_update_server":
         return await _update_server(services, i18n)
     if kind == "admin_list_skills":
@@ -298,7 +317,9 @@ async def _dispatch_admin_frame(
     if kind == "admin_list_rules":
         return _rules_frame()
     if kind == "admin_generate":
-        return await _generate(services, caller_room, fs, frame, i18n)
+        return await _generate(
+            services, caller_room, fs, frame, i18n, reauthorize=reauthorize
+        )
     return _error("bad_request", i18n)
 
 
@@ -769,7 +790,14 @@ def _keeper_count(keystore: Keystore, room: str) -> int:
     return sum(1 for e in keystore.entries() if e.room == room and e.role == "keeper")
 
 
-def _update_key(keystore: Keystore, caller_room: str, frame: dict[str, Any], i18n: I18n) -> dict[str, Any]:
+async def _update_key(
+    keystore: Keystore,
+    caller_room: str,
+    frame: dict[str, Any],
+    i18n: I18n,
+    *,
+    reauthorize: Any = None,
+) -> dict[str, Any]:
     key_id = str(frame.get("id") or "").strip()
     updates: dict[str, str] = {}
     if "room" in frame:
@@ -804,11 +832,22 @@ def _update_key(keystore: Keystore, caller_room: str, frame: dict[str, Any], i18
         if entry.role == "keeper" and updates.get("role", "keeper") != "keeper":
             if _keeper_count(keystore, caller_room) <= 1:
                 return _last_keeper_error(i18n)
+        try:
+            await confirm_live_authorization(reauthorize)
+        except AuthorizationRevoked:
+            return _error("forbidden", i18n)
         keystore.update(key, **updates)
     return _keys_frame(keystore, caller_room)
 
 
-def _delete_key(keystore: Keystore, caller_room: str, frame: dict[str, Any], i18n: I18n) -> dict[str, Any]:
+async def _delete_key(
+    keystore: Keystore,
+    caller_room: str,
+    frame: dict[str, Any],
+    i18n: I18n,
+    *,
+    reauthorize: Any = None,
+) -> dict[str, Any]:
     key_id = str(frame.get("id") or "").strip()
     with keystore.persisted_mutation():
         key = _resolve_key(keystore, key_id)
@@ -821,6 +860,10 @@ def _delete_key(keystore: Keystore, caller_room: str, frame: dict[str, Any], i18
         # strand the room without any way to recover keeper access.
         if entry.role == "keeper" and _keeper_count(keystore, caller_room) <= 1:
             return _last_keeper_error(i18n)
+        try:
+            await confirm_live_authorization(reauthorize)
+        except AuthorizationRevoked:
+            return _error("forbidden", i18n)
         keystore.remove(key)
     return _keys_frame(keystore, caller_room)
 
@@ -831,6 +874,8 @@ async def _delete_room(
     caller_room: str,
     frame: dict[str, Any],
     i18n: I18n,
+    *,
+    reauthorize: Any = None,
 ) -> dict[str, Any]:
     room = str(frame.get("room") or "").strip()
     if not room:
@@ -838,6 +883,10 @@ async def _delete_room(
     if room != caller_room:  # a keeper can only delete its OWN room
         return _error("forbidden", i18n)
     with keystore.persisted_mutation():
+        try:
+            await confirm_live_authorization(reauthorize)
+        except AuthorizationRevoked:
+            return _error("forbidden", i18n)
         removed = keystore.remove_room(room)
         if removed <= 0:
             return _error("not_found", i18n)
@@ -852,6 +901,8 @@ async def _export_room(
     caller_room: str,
     frame: dict[str, Any],
     i18n: I18n,
+    *,
+    reauthorize: Any = None,
 ) -> dict[str, Any]:
     room = str(frame.get("room") or "").strip()
     if not room:
@@ -860,7 +911,12 @@ async def _export_room(
         return _error("forbidden", i18n)
     path = str(frame.get("path") or "").strip()
     try:
-        return _room_op_frame("export", await export_room(services, keystore, room, path))
+        return _room_op_frame(
+            "export",
+            await export_room(services, keystore, room, path, reauthorize=reauthorize),
+        )
+    except AuthorizationRevoked:
+        return _error("forbidden", i18n)
     except Exception:
         return _error("op_failed", i18n)
 
@@ -871,6 +927,8 @@ async def _import_room(
     caller_room: str,
     frame: dict[str, Any],
     i18n: I18n,
+    *,
+    reauthorize: Any = None,
 ) -> dict[str, Any]:
     path = str(frame.get("path") or "").strip()
     if not path:
@@ -882,8 +940,13 @@ async def _import_room(
         return _error("forbidden", i18n)
     try:
         return _room_op_frame(
-            "import", await import_room(services, keystore, path, expected_room=caller_room)
+            "import",
+            await import_room(
+                services, keystore, path, expected_room=caller_room, reauthorize=reauthorize
+            ),
         )
+    except AuthorizationRevoked:
+        return _error("forbidden", i18n)
     except Exception:
         return _error("op_failed", i18n)
 
@@ -896,6 +959,7 @@ async def _delete_room_data(
     i18n: I18n,
     *,
     hub: Any = None,
+    reauthorize: Any = None,
 ) -> dict[str, Any]:
     room = str(frame.get("room") or "").strip()
     if not room:
@@ -908,15 +972,21 @@ async def _delete_room_data(
     backup_path = ""
     try:
         if backup:
-            backup_result = await export_room(services, keystore, room, path)
+            backup_result = await export_room(
+                services, keystore, room, path, reauthorize=reauthorize
+            )
             backup_path = str(backup_result.get("path") or "")
         # The hub rides along so a DIRECT caller drops the room's in-process turn lock
         # with the room (M23 WS1). This path is not one: the session layer serializes
         # destructive admin frames under that very lock, the in-op disposal declines on
         # a held lock, and net/session disposes right after the lock releases.
-        result = await delete_room_data(services, keystore, room, hub=hub)
+        result = await delete_room_data(
+            services, keystore, room, hub=hub, reauthorize=reauthorize
+        )
         await clear_keeper_bindings_for_room(services.store, room)
         await clear_bindings_for_session(services.store, session_key_for_room(room))
+    except AuthorizationRevoked:
+        return _error("forbidden", i18n)
     except Exception:
         return _error("op_failed", i18n)
     if backup_path:
@@ -930,6 +1000,8 @@ async def _reset_room(
     caller_room: str,
     frame: dict[str, Any],
     i18n: I18n,
+    *,
+    reauthorize: Any = None,
 ) -> dict[str, Any]:
     """Wipe one room's campaign state in place — the button behind an in-place
     campaign restart. Unlike ``_delete_room_data`` it takes NO backup and removes
@@ -945,7 +1017,15 @@ async def _reset_room(
     if scope not in RESET_SCOPES:
         return _error("bad_request", i18n)
     try:
-        result = await reset_room_state(services, chat_key_for_room(room), scope=scope, keystore=keystore)
+        result = await reset_room_state(
+            services,
+            chat_key_for_room(room),
+            scope=scope,
+            keystore=keystore,
+            reauthorize=reauthorize,
+        )
+    except AuthorizationRevoked:
+        return _error("forbidden", i18n)
     except Exception:
         return _error("op_failed", i18n)
     result["room"] = room
@@ -1063,6 +1143,8 @@ async def _generate(
     fs: FsAdapter | None,
     frame: dict[str, Any],
     i18n: I18n,
+    *,
+    reauthorize: Any = None,
 ) -> dict[str, Any]:
     """Answer `admin_generate`: run the matching `agent.forge` engine and reply
     `admin_generated`. Never `eval`/`exec`s anything — see `agent.forge`'s module docstring;
@@ -1085,13 +1167,16 @@ async def _generate(
         # Mirrors `net.session.SessionCore._ctx_for`'s AgentCtx construction: a keeper-role
         # context scoped to the CALLER'S room, so the generated module lands in the calling
         # keeper's own knowledge pool via `agent.kp_tools_knowledge.DocumentTools.upload_document`.
+        extra: dict[str, Any] = {"role": _KEEPER_ROLE}
+        if reauthorize is not None:
+            extra["reauthorize"] = reauthorize
         ctx = AgentCtx(
             chat_key=room_chat_key,
             user_id="keeper",
             platform="tui",
             locale=i18n.locale,
             fs=fs,
-            extra={"role": _KEEPER_ROLE},
+            extra=extra,
         )
         result = await generate_and_install_module(services, ctx, description)
     return _generated_frame(kind, result)

--- a/net/room_backup.py
+++ b/net/room_backup.py
@@ -20,6 +20,7 @@ from agent.document_manager import document_point_id
 from agent.services import Services
 from gateway.session import SessionSource
 from infra.file_permissions import atomic_write_private, ensure_private_directory, restrict_file
+from infra.live_auth import AuthorizationRevoked, confirm_live_authorization
 from infra.media_store import (
     ALLOWED_AUDIO_MIMES,
     ALLOWED_IMAGE_MIMES,
@@ -587,7 +588,14 @@ def room_key_entries(
     return entries
 
 
-async def export_room(services: Services, keystore: Keystore, room: str, path: str = "") -> dict[str, Any]:
+async def export_room(
+    services: Services,
+    keystore: Keystore,
+    room: str,
+    path: str = "",
+    *,
+    reauthorize: Any = None,
+) -> dict[str, Any]:
     room = room.strip()
     if not room:
         raise ValueError("snapshot room is empty")
@@ -627,6 +635,9 @@ async def export_room(services: Services, keystore: Keystore, room: str, path: s
     encoded = json.dumps(snapshot, ensure_ascii=False, indent=2)
     if len(encoded.encode("utf-8")) > MAX_BACKUP_FILE_BYTES:
         raise ValueError("room snapshot byte limit exceeded")
+    # Linearization point: last reauth success → this write is authorized. A key
+    # revoked during the secret read must not create or overwrite the artifact.
+    await confirm_live_authorization(reauthorize)
     atomic_write_private(target, encoded)
     return {
         "room": room,
@@ -1148,6 +1159,7 @@ async def reset_room_state(
     *,
     scope: str = "story",
     keystore: Keystore | None = None,
+    reauthorize: Any = None,
 ) -> dict[str, Any]:
     """Wipe part of one room's campaign state in place, keeping keystore keys,
     channel/keeper bindings and live connections. ``scope`` chooses how much:
@@ -1174,6 +1186,10 @@ async def reset_room_state(
     # room-scoped by an exact COLUMN — a dotted-neighbor room can no longer alias this
     # room's rows, so the pre-M17 prefix-ambiguity guard is structurally unnecessary here.
     registry = room_registry()
+    # Scope lookup is the preflight; facet hooks are the first mutation. Last reauth
+    # success here is the linearization point — do not try to unwind a hook that
+    # already ran.
+    await confirm_live_authorization(reauthorize)
     # Facet-owned disposal a target list cannot name — a facet that owns a SLICE of a
     # family another facet owns wholesale (`infra.room_facets`). It runs FIRST: such a
     # hook selects its slice by reading the records the target lists below are about to
@@ -1234,6 +1250,7 @@ async def delete_room_data(
     room: str,
     *,
     hub: Any | None = None,
+    reauthorize: Any = None,
 ) -> dict[str, Any]:
     """Delete one room entirely. ``hub`` lets facets that own in-process state dispose of
     it too; a caller without a bus (the CLI) passes none and leaks nothing."""
@@ -1247,6 +1264,9 @@ async def delete_room_data(
     keys_mutated = False
 
     try:
+        # Capture + media stage are the preflight (the stage is a private recovery
+        # copy, not a live mutation). Last reauth success → the delete is authorized.
+        await confirm_live_authorization(reauthorize)
         deleted_rows = await _atomic_store_update(
             services,
             delete_rows=state.rows,
@@ -1275,6 +1295,10 @@ async def delete_room_data(
             hook = facet.on_delete
             if hook is not None:
                 await hook(facet_ctx)
+    except AuthorizationRevoked:
+        # No live mutation has started — discard the private stage and fail closed.
+        _discard_stage(stage_root)
+        raise
     except BaseException:
         rollback_state = _RoomState(
             rows=state.rows,
@@ -1317,6 +1341,7 @@ async def import_room(
     path: str,
     *,
     expected_room: str = "",
+    reauthorize: Any = None,
 ) -> dict[str, Any]:
     expected = expected_room.strip()
     source = _resolve_import_path(services, path, expected)
@@ -1630,6 +1655,9 @@ async def import_room(
     snapshots_before = await _capture_room_snapshots(services, new_chat_key)
     cleared_storages = sorted(room_registry().storages_not_exported())
     created_media_hashes: set[str] = set()
+    # Validation + capture are the preflight. Last reauth success → the first
+    # store write is authorized. Do not try to unwind `_atomic_store_update`.
+    await confirm_live_authorization(reauthorize)
     try:
         await _atomic_store_update(
             services,

--- a/tests/architecture/test_layer_imports.py
+++ b/tests/architecture/test_layer_imports.py
@@ -1,0 +1,38 @@
+"""Production layering: ``agent/`` must not import ``net/``.
+
+``agent/`` is the Keeper brain; ``net/`` is the transport/admin surface.
+A reverse import (for example ``agent.kp_tools_*`` pulling
+``net.room_backup``) couples the model tools to a carrier and breaks the
+layer stack in AGENTS.md. Shared helpers belong in ``infra/``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_DIR = REPO_ROOT / "agent"
+
+
+def _imported_modules(tree: ast.AST) -> set[str]:
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    return imported
+
+
+def test_agent_never_imports_net() -> None:
+    violations: list[str] = []
+    for path in sorted(AGENT_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for module in sorted(_imported_modules(tree)):
+            if module == "net" or module.startswith("net."):
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(f"{rel} imports {module}")
+    assert not violations, (
+        "agent/ must not import net/ (put shared helpers in infra/):\n" + "\n".join(violations)
+    )

--- a/tests/gateway/test_command_gates.py
+++ b/tests/gateway/test_command_gates.py
@@ -651,7 +651,7 @@ async def test_import_world_runs_for_the_keeper(tmp_path):
         platform="tui",
         locale="en",
         fs=LocalFs(str(tmp_path)),
-        extra={"role": "keeper", "attachment_names": ["w.json"]},
+        extra={"role": "keeper", "attachment_names": ["w.json"], "reauthorize": lambda: True},
     )
 
     reply = await router.dispatch(keeper, ".import world")

--- a/tests/gateway/test_commands.py
+++ b/tests/gateway/test_commands.py
@@ -1523,9 +1523,12 @@ async def test_model_key_rejected_in_public_channel_but_accepted_in_dm():
 # ---------------------------------------------------------------------------
 
 
-def _tui_ctx(role: str, *, room: str = "room1") -> AgentCtx:
+def _tui_ctx(role: str, *, room: str = "room1", reauthorize=None) -> AgentCtx:
+    extra: dict = {"role": role}
+    if reauthorize is not None:
+        extra["reauthorize"] = reauthorize
     return AgentCtx(
-        chat_key=f"tui:group:{room}", user_id="u1", platform="tui", locale="en", extra={"role": role}
+        chat_key=f"tui:group:{room}", user_id="u1", platform="tui", locale="en", extra=extra
     )
 
 
@@ -1603,7 +1606,7 @@ async def test_tui_keeper_role_is_allowed_keeper_only_commands():
     services = _mutable_services()
     keystore = Keystore()
     router = CommandRouter(services, keystore=keystore)
-    keeper = _tui_ctx("keeper")
+    keeper = _tui_ctx("keeper", reauthorize=lambda: True)
     i18n = services.i18n.with_locale("en")
 
     allowed = await router.dispatch(keeper, ".model set anthropic")

--- a/tests/gateway/test_commands_reset.py
+++ b/tests/gateway/test_commands_reset.py
@@ -187,7 +187,13 @@ async def test_reset_zh_alias_and_scope_words(tmp_path):
     router = CommandRouter(services)
     chat_key = "tui:group:room-2"
     await _seed_room(services, chat_key)
-    ctx = AgentCtx(chat_key=chat_key, user_id="k1", platform="tui", locale="zh", extra={"role": "keeper"})
+    ctx = AgentCtx(
+        chat_key=chat_key,
+        user_id="k1",
+        platform="tui",
+        locale="zh",
+        extra={"role": "keeper", "reauthorize": lambda: True},
+    )
 
     # `.重开 全部` arms the full-wipe scope in Chinese.
     armed = await router.dispatch(ctx, ".重开 全部")
@@ -209,7 +215,13 @@ async def test_reset_confirm_pushes_a_reset_flagged_state_frame(tmp_path):
     await hub.subscribe(chat_key, member)
     router = CommandRouter(services, hub=hub)
     await _seed_room(services, chat_key)
-    ctx = AgentCtx(chat_key=chat_key, user_id="k1", platform="tui", locale="en", extra={"role": "keeper"})
+    ctx = AgentCtx(
+        chat_key=chat_key,
+        user_id="k1",
+        platform="tui",
+        locale="en",
+        extra={"role": "keeper", "reauthorize": lambda: True},
+    )
 
     await router.dispatch(ctx, ".reset")
     member.events.clear()  # only care about what the confirm publishes

--- a/tests/gateway/test_live_reauth.py
+++ b/tests/gateway/test_live_reauth.py
@@ -1,0 +1,284 @@
+"""Deterministic races: a revoked keeper must not mutate after a long preflight.
+
+The transport choke point refreshes authorization when it takes the room lock.
+These tests pause at the later commit boundary (after availability / snapshot
+parse, before reset/restore/import/export write), revoke the key on another
+task, then release — the operation must fail closed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from agent.chronicle import CHRONICLE_TURN_KEY, chronicle_turn
+from agent.context import AgentCtx, LocalFs
+from agent.history import append_turn, load_chain
+from agent.services import build_services
+from agent.undo import capture
+from gateway.commands import CommandRouter
+from infra.config import Settings
+from infra.embeddings import FakeEmbeddings
+from infra.i18n import get_i18n
+from infra.llm import FakeLLM
+from net.keystore import Keystore
+from net.room_backup import chat_key_for_room, export_room
+
+
+def _services(tmp_path: Path | None = None):
+    settings = Settings(locale="en", data_dir=str(tmp_path) if tmp_path else "./data")
+    return build_services(settings, llm=FakeLLM(script=[]), embeddings=FakeEmbeddings(64))
+
+
+def _barrier(reached: asyncio.Event, release: asyncio.Event, keystore: Keystore, key: str):
+    async def _reauthorize() -> bool:
+        reached.set()
+        await release.wait()
+        entry = keystore.get(key, purpose=None)
+        return entry is not None and entry.role == "keeper"
+
+    return _reauthorize
+
+
+def _keeper_ctx(
+    chat_key: str,
+    *,
+    reauthorize,
+    fs=None,
+    extra: dict | None = None,
+) -> AgentCtx:
+    payload = {"role": "keeper", "reauthorize": reauthorize}
+    if extra:
+        payload.update(extra)
+    return AgentCtx(
+        chat_key=chat_key,
+        user_id="kp",
+        platform="tui",
+        locale="en",
+        fs=fs,
+        extra=payload,
+    )
+
+
+async def _revoke_after_preflight(
+    reached: asyncio.Event,
+    release: asyncio.Event,
+    keystore: Keystore,
+    key: str,
+) -> None:
+    await reached.wait()
+    keystore.remove(key)
+    release.set()
+
+
+async def test_undo_live_reauth_after_preflight_leaves_the_room_unchanged() -> None:
+    services = _services()
+    keystore = Keystore()
+    caller = keystore.add(room="undo-race", role="keeper")
+    chat_key = "undo-race"
+    await append_turn(services, chat_key, "chat_history", user_message="one", reply="1", turn=1)
+    await services.store.state_set(chat_key, CHRONICLE_TURN_KEY, "1")
+    await services.documents.put(chat_key, "note", "log", {"category": "log", "content": "before"})
+    await capture(services, chat_key, 1)
+
+    reached = asyncio.Event()
+    release = asyncio.Event()
+    router = CommandRouter(services)
+    ctx = _keeper_ctx(chat_key, reauthorize=_barrier(reached, release, keystore, caller))
+
+    task = asyncio.create_task(router.dispatch(ctx, ".undo 1"))
+    await _revoke_after_preflight(reached, release, keystore, caller)
+    reply = await task
+
+    assert reply == get_i18n("en").t("commands.undo.denied")
+    assert await chronicle_turn(services.store, chat_key) == 1
+    note = await services.documents.get(chat_key, "note", "log")
+    assert note is not None and note.data.get("content") == "before"
+    assert [message["content"] for message in await load_chain(services, chat_key, "chat_history")] == [
+        "one",
+        "1",
+    ]
+
+
+async def test_save_load_live_reauth_after_preflight_leaves_storage_unchanged(tmp_path) -> None:
+    services = _services(tmp_path)
+    keystore = Keystore()
+    room = "save-load-race"
+    caller = keystore.add(room=room, role="keeper")
+    chat_key = chat_key_for_room(room)
+    await services.store.state_set(chat_key, "scene", "the docks")
+    await services.documents.put(chat_key, "note", "log", {"category": "log", "content": "checkpoint"})
+    exported = await export_room(services, keystore, room, "checkpoint")
+    await services.store.state_set(chat_key, "scene", "OVERWRITTEN")
+    await services.documents.put(chat_key, "note", "log", {"category": "log", "content": "live"})
+
+    reached = asyncio.Event()
+    release = asyncio.Event()
+    router = CommandRouter(services, keystore=keystore)
+    ctx = _keeper_ctx(chat_key, reauthorize=_barrier(reached, release, keystore, caller))
+
+    task = asyncio.create_task(router.dispatch(ctx, ".save load checkpoint"))
+    await _revoke_after_preflight(reached, release, keystore, caller)
+    reply = await task
+
+    assert reply == get_i18n("en").t("commands.save.denied")
+    assert Path(exported["path"]).is_file()
+    assert await services.store.state_get(chat_key, "scene") == "OVERWRITTEN"
+    note = await services.documents.get(chat_key, "note", "log")
+    assert note is not None and note.data.get("content") == "live"
+
+
+async def test_save_export_live_reauth_before_write_does_not_create_or_overwrite(tmp_path) -> None:
+    services = _services(tmp_path)
+    keystore = Keystore()
+    room = "save-export-race"
+    caller = keystore.add(room=room, role="keeper")
+    chat_key = chat_key_for_room(room)
+    await services.store.state_set(chat_key, "scene", "secret docks")
+    existing = await export_room(services, keystore, room, "named")
+    original = Path(existing["path"]).read_bytes()
+
+    reached = asyncio.Event()
+    release = asyncio.Event()
+    router = CommandRouter(services, keystore=keystore)
+    ctx = _keeper_ctx(chat_key, reauthorize=_barrier(reached, release, keystore, caller))
+
+    task = asyncio.create_task(router.dispatch(ctx, ".save named"))
+    await _revoke_after_preflight(reached, release, keystore, caller)
+    reply = await task
+
+    assert reply == get_i18n("en").t("commands.save.denied")
+    assert Path(existing["path"]).read_bytes() == original
+    assert "secret docks" not in reply
+    assert existing["path"] not in (reply or "")
+
+
+async def test_import_world_live_reauth_after_parse_writes_nothing(tmp_path) -> None:
+    services = _services(tmp_path)
+    keystore = Keystore()
+    caller = keystore.add(room="world-race", role="keeper")
+    chat_key = "tui:group:world-race"
+    card = {
+        "name": "Manor",
+        "extensions": {"loreweaver_hooks": ["on('turn_start', () => {});"]},
+        "character_book": {"entries": [{"comment": "[InitVar]", "content": '{"真凶": ["butler", "t"]}'}]},
+    }
+    (tmp_path / "w.json").write_text(json.dumps(card, ensure_ascii=False), encoding="utf-8")
+
+    reached = asyncio.Event()
+    release = asyncio.Event()
+    router = CommandRouter(services)
+    ctx = _keeper_ctx(
+        chat_key,
+        reauthorize=_barrier(reached, release, keystore, caller),
+        fs=LocalFs(str(tmp_path)),
+        extra={"attachment_names": ["w.json"]},
+    )
+
+    task = asyncio.create_task(router.dispatch(ctx, ".import world"))
+    await _revoke_after_preflight(reached, release, keystore, caller)
+    reply = await task
+
+    assert reply == get_i18n("en").t("charcard.commands.import.world_denied")
+    assert await services.store.state_get(chat_key, "world_import") is None
+    assert await services.store.state_get(chat_key, "room_hooks") is None
+
+
+def _tui_keeper_without_callback(chat_key: str, **kwargs) -> AgentCtx:
+    return AgentCtx(
+        chat_key=chat_key,
+        user_id="kp",
+        platform="tui",
+        locale="en",
+        extra={"role": "keeper"},
+        **kwargs,
+    )
+
+
+async def test_tui_keeper_without_reauthorize_callback_is_denied() -> None:
+    """A stamped keeper role on a network platform is not enough: no live callback
+    means the key cannot be re-checked, so the commit must fail closed."""
+    services = _services()
+    router = CommandRouter(services, keystore=Keystore())
+    i18n = get_i18n("en")
+    chat_key = "tui:group:no-callback"
+
+    reset = await router.dispatch(_tui_keeper_without_callback(chat_key), ".reset")
+    assert reset == i18n.t("commands.reset.denied")
+    assert await services.store.state_get(chat_key, "reset_pending") is None
+
+    model = await router.dispatch(_tui_keeper_without_callback(chat_key), ".model")
+    assert model == i18n.t("commands.model.denied")
+
+    await append_turn(services, chat_key, "chat_history", user_message="one", reply="1", turn=1)
+    await services.store.state_set(chat_key, CHRONICLE_TURN_KEY, "1")
+    await capture(services, chat_key, 1)
+    undo = await router.dispatch(_tui_keeper_without_callback(chat_key), ".undo 1")
+    assert undo == i18n.t("commands.undo.denied")
+    assert await chronicle_turn(services.store, chat_key) == 1
+
+    save = await router.dispatch(_tui_keeper_without_callback(chat_key), ".save named")
+    assert save == i18n.t("commands.save.denied")
+
+
+async def test_tui_keeper_without_callback_cannot_import_world(tmp_path) -> None:
+    services = _services(tmp_path)
+    router = CommandRouter(services)
+    chat_key = "tui:group:world-no-callback"
+    (tmp_path / "w.json").write_text(json.dumps({"name": "Manor"}), encoding="utf-8")
+    ctx = AgentCtx(
+        chat_key=chat_key,
+        user_id="kp",
+        platform="tui",
+        locale="en",
+        fs=LocalFs(str(tmp_path)),
+        extra={"role": "keeper", "attachment_names": ["w.json"]},
+    )
+
+    reply = await router.dispatch(ctx, ".import world")
+
+    assert reply == get_i18n("en").t("charcard.commands.import.world_denied")
+    assert await services.store.state_get(chat_key, "world_import") is None
+
+
+async def test_module_upload_reauths_after_progress_immediately_before_store(tmp_path, monkeypatch) -> None:
+    """Progress emit may await; the live check must sit against store_document, not before it."""
+    from agent.kp_tools_knowledge import DocumentTools
+
+    services = _services(tmp_path)
+    (tmp_path / "mod.txt").write_text("The marsh holds a secret.", encoding="utf-8")
+    order: list[str] = []
+    stored = False
+
+    async def _progress(stage: str, detail: str = "") -> None:
+        order.append(f"progress:{stage}")
+        await asyncio.sleep(0)
+
+    async def _reauthorize() -> bool:
+        order.append("reauth")
+        return False
+
+    async def _store_document(**kwargs):
+        nonlocal stored
+        stored = True
+        order.append("store")
+        return 1
+
+    monkeypatch.setattr(services.vector_db, "store_document", _store_document)
+    ctx = AgentCtx(
+        chat_key="tui:group:module-order",
+        user_id="kp",
+        platform="tui",
+        locale="en",
+        fs=LocalFs(str(tmp_path)),
+        extra={"role": "keeper", "reauthorize": _reauthorize},
+    )
+
+    reply = await DocumentTools(services).upload_document(
+        ctx, file_path="mod.txt", doc_type="module", progress=_progress
+    )
+
+    assert reply == get_i18n("en").t("rooms.denied")
+    assert stored is False
+    assert order == ["progress:read", "progress:embed", "reauth"]

--- a/tests/net/test_live_reauth.py
+++ b/tests/net/test_live_reauth.py
@@ -1,0 +1,228 @@
+"""Admin / room_backup live-reauth at the commit boundary.
+
+A revoked keeper must not import or delete after the expensive preflight, and
+a failed reauth must not create or overwrite a backup. The last successful
+reauth is the linearization point.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from agent.services import build_services
+from infra.config import LLMSettings, Settings
+from infra.embeddings import FakeEmbeddings
+from infra.i18n import get_i18n
+from infra.llm import FakeLLM
+from infra.providers import MutableLLM
+from infra.live_auth import (
+    AuthorizationRevoked,
+    confirm_live_authorization,
+    invoke_reauthorize,
+)
+from net.admin import AdminService
+from net.keystore import Keystore
+from net.room_backup import chat_key_for_room, export_room
+
+
+def _services(data_dir: str = "./data"):
+    settings = Settings(
+        locale="en",
+        data_dir=data_dir,
+        llm=LLMSettings(provider="openai", chat_model="gpt-4o"),
+    )
+    llm = MutableLLM(settings, builder=lambda s: FakeLLM(script=[]))
+    return build_services(settings, llm=llm, embeddings=FakeEmbeddings(64))
+
+
+def _barrier(reached: asyncio.Event, release: asyncio.Event, keystore: Keystore, key: str):
+    async def _reauthorize() -> bool:
+        reached.set()
+        await release.wait()
+        entry = keystore.get(key, purpose=None)
+        return entry is not None and entry.role == "keeper"
+
+    return _reauthorize
+
+
+async def _revoke_after_preflight(
+    reached: asyncio.Event,
+    release: asyncio.Event,
+    keystore: Keystore,
+    key: str,
+) -> None:
+    await reached.wait()
+    keystore.remove(key)
+    release.set()
+
+
+async def test_invoke_reauthorize_accepts_sync_and_awaitable_and_fails_closed() -> None:
+    assert await invoke_reauthorize(None) is True
+    assert await invoke_reauthorize(None, missing_ok=False) is False
+    assert await invoke_reauthorize(lambda: True) is True
+    assert await invoke_reauthorize(lambda: False) is False
+
+    async def _ok() -> bool:
+        return True
+
+    async def _no() -> bool:
+        return False
+
+    assert await invoke_reauthorize(_ok) is True
+    assert await invoke_reauthorize(_no) is False
+
+    def _boom() -> bool:
+        raise RuntimeError("refresh failed")
+
+    assert await invoke_reauthorize(_boom) is False
+    assert await invoke_reauthorize("not-callable") is False
+
+    try:
+        await confirm_live_authorization(lambda: False)
+    except AuthorizationRevoked as exc:
+        assert str(exc) == ""
+    else:
+        raise AssertionError("expected AuthorizationRevoked")
+
+
+async def test_admin_import_live_reauth_after_preflight_leaves_room_unchanged(tmp_path) -> None:
+    services = _services(str(tmp_path))
+    keystore = Keystore()
+    room = "arkham"
+    caller = keystore.add(room=room, role="keeper", name="Keeper")
+    chat_key = chat_key_for_room(room)
+    await services.store.state_set(chat_key, "scene", "the docks")
+    await services.documents.put(chat_key, "note", "log", {"category": "log", "content": "checkpoint"})
+    exported = await export_room(services, keystore, room, "checkpoint")
+    await services.store.state_set(chat_key, "scene", "OVERWRITTEN")
+    await services.documents.put(chat_key, "note", "log", {"category": "log", "content": "live"})
+
+    reached = asyncio.Event()
+    release = asyncio.Event()
+    admin = AdminService(services, keystore)
+    task = asyncio.create_task(
+        admin.dispatch(
+            "keeper",
+            room,
+            {"type": "admin_import_room", "path": Path(exported["path"]).name},
+            get_i18n("en"),
+            reauthorize=_barrier(reached, release, keystore, caller),
+        )
+    )
+    await _revoke_after_preflight(reached, release, keystore, caller)
+    reply = await task
+
+    assert reply["type"] == "admin_error"
+    assert reply["code"] == "forbidden"
+    assert reply["message"] == get_i18n("en").t("tui.admin.error.forbidden")
+    assert exported["path"] not in reply["message"]
+    assert await services.store.state_get(chat_key, "scene") == "OVERWRITTEN"
+    note = await services.documents.get(chat_key, "note", "log")
+    assert note is not None and note.data.get("content") == "live"
+
+
+async def test_admin_delete_live_reauth_after_preflight_leaves_storage_and_skips_backup(
+    tmp_path,
+) -> None:
+    services = _services(str(tmp_path))
+    keystore = Keystore()
+    room = "arkham"
+    caller = keystore.add(room=room, role="keeper", name="Keeper")
+    backup_keeper = keystore.add(room=room, role="keeper", name="Other")
+    chat_key = chat_key_for_room(room)
+    await services.store.state_set(chat_key, "scene", "the docks")
+    await services.documents.put(chat_key, "lore", "l1", {"title": "Secret", "content": "do not leak"})
+    backups_before = set((tmp_path / "room_backups").glob("**/*")) if (tmp_path / "room_backups").exists() else set()
+
+    reached = asyncio.Event()
+    release = asyncio.Event()
+    admin = AdminService(services, keystore)
+    task = asyncio.create_task(
+        admin.dispatch(
+            "keeper",
+            room,
+            {"type": "admin_delete_room_data", "room": room, "backup": True, "path": "must-not-write"},
+            get_i18n("en"),
+            reauthorize=_barrier(reached, release, keystore, caller),
+        )
+    )
+    await _revoke_after_preflight(reached, release, keystore, caller)
+    reply = await task
+
+    assert reply["type"] == "admin_error"
+    assert reply["code"] == "forbidden"
+    assert reply["message"] == get_i18n("en").t("tui.admin.error.forbidden")
+    assert "must-not-write" not in reply["message"]
+    assert "do not leak" not in reply["message"]
+    assert await services.store.state_get(chat_key, "scene") == "the docks"
+    lore = await services.documents.get(chat_key, "lore", "l1")
+    assert lore is not None and lore.data.get("content") == "do not leak"
+    assert keystore.get(backup_keeper, purpose=None) is not None
+    backups_after = set((tmp_path / "room_backups").glob("**/*")) if (tmp_path / "room_backups").exists() else set()
+    new_files = {path for path in backups_after - backups_before if path.is_file()}
+    assert new_files == set()
+
+
+async def test_admin_delete_without_backup_live_reauth_leaves_storage_unchanged(tmp_path) -> None:
+    services = _services(str(tmp_path))
+    keystore = Keystore()
+    room = "arkham"
+    caller = keystore.add(room=room, role="keeper", name="Keeper")
+    spare = keystore.add(room=room, role="keeper", name="Spare")
+    chat_key = chat_key_for_room(room)
+    await services.store.state_set(chat_key, "scene", "the docks")
+    await services.documents.put(chat_key, "lore", "l1", {"title": "Secret", "content": "keep"})
+
+    reached = asyncio.Event()
+    release = asyncio.Event()
+    admin = AdminService(services, keystore)
+    task = asyncio.create_task(
+        admin.dispatch(
+            "keeper",
+            room,
+            {"type": "admin_delete_room_data", "room": room, "backup": False},
+            get_i18n("en"),
+            reauthorize=_barrier(reached, release, keystore, caller),
+        )
+    )
+    await _revoke_after_preflight(reached, release, keystore, caller)
+    reply = await task
+
+    assert reply["type"] == "admin_error"
+    assert reply["code"] == "forbidden"
+    assert await services.store.state_get(chat_key, "scene") == "the docks"
+    lore = await services.documents.get(chat_key, "lore", "l1")
+    assert lore is not None and lore.data.get("content") == "keep"
+    assert keystore.get(spare, purpose=None) is not None
+
+
+async def test_admin_export_live_reauth_before_write_does_not_create_file(tmp_path) -> None:
+    services = _services(str(tmp_path))
+    keystore = Keystore()
+    room = "arkham"
+    caller = keystore.add(room=room, role="keeper", name="Keeper")
+    chat_key = chat_key_for_room(room)
+    await services.store.state_set(chat_key, "scene", "secret docks")
+
+    reached = asyncio.Event()
+    release = asyncio.Event()
+    admin = AdminService(services, keystore)
+    task = asyncio.create_task(
+        admin.dispatch(
+            "keeper",
+            room,
+            {"type": "admin_export_room", "room": room, "path": "must-not-write"},
+            get_i18n("en"),
+            reauthorize=_barrier(reached, release, keystore, caller),
+        )
+    )
+    await _revoke_after_preflight(reached, release, keystore, caller)
+    reply = await task
+
+    assert reply["type"] == "admin_error"
+    assert reply["code"] == "forbidden"
+    leftovers = list((tmp_path / "room_backups").glob("**/must-not-write.json")) if (tmp_path / "room_backups").exists() else []
+    assert leftovers == []
+    assert "must-not-write" not in reply["message"]
+    assert "secret docks" not in reply["message"]

--- a/tests/net/test_tui_server.py
+++ b/tests/net/test_tui_server.py
@@ -48,7 +48,16 @@ def _services(responder=None):
 
 def _room_ctx(room: str, *, user_id: str = "seed", fs=None) -> AgentCtx:
     chat_key = SessionSource(platform="tui", chat_type="group", chat_id=room).chat_key()
-    return AgentCtx(chat_key=chat_key, user_id=user_id, platform="tui", locale="en", fs=fs)
+    # Same extra key SessionCore stamps: a TUI ctx without `reauthorize` is
+    # fail-closed at the first live-auth write (e.g. `upload_document`).
+    return AgentCtx(
+        chat_key=chat_key,
+        user_id=user_id,
+        platform="tui",
+        locale="en",
+        fs=fs,
+        extra={"reauthorize": lambda: True},
+    )
 
 
 async def _start(server: TuiServer) -> str:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add transport-neutral live authorization with network fail-closed semantics
- recheck Keeper access after expensive preflight and immediately before commit boundaries
- cover undo, save/load/export, room lifecycle, key mutation, world import, and module storage
- preserve CLI auto-master and prevent agent→net layer inversion

## Tests
- deterministic revoke-during-preflight races
- full backend pytest, Ruff, and i18n
- combined all-PR integration suite
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8df0c996-410d-4440-a105-824b093328bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8df0c996-410d-4440-a105-824b093328bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

