### PR TITLE
chore(cloud): add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Loreweaver",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for Loreweaver.
+# Installs the two toolchains the default image lacks (uv for the Python engine,
+# bun for the TypeScript clients), then refreshes all locked dependencies.
+# Safe to run repeatedly and against cached/snapshot state.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# --- uv (Python engine) --------------------------------------------------
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+# uv's installer writes ~/.local/bin/env and the profile snippet; source it so
+# this non-interactive shell can see uv immediately.
+[ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env"
+export PATH="$HOME/.local/bin:$PATH"
+
+# --- bun (TypeScript clients) --------------------------------------------
+if ! command -v bun >/dev/null 2>&1; then
+  curl -fsSL https://bun.sh/install | bash
+fi
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+# --- Python deps (matches .github/workflows/ci.yml) ----------------------
+# anthropic + gemini: the two native (non-OpenAI) provider classes.
+# ejs: the QuickJS sandbox the untrusted-code lanes run in.
+# --locked asserts uv.lock is current; the dev group (pytest/ruff) is default.
+uv sync --locked --extra anthropic --extra gemini --extra ejs
+
+# --- TypeScript client deps ----------------------------------------------
+( cd clients/protocol && bun install )
+( cd clients/tui && bun install )
+
+echo "Loreweaver install complete: $(uv --version), bun $(bun --version)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a Cloud Agent development environment for Loreweaver (previously greenfield — no `.cursor/environment.json`).

- `.cursor/environment.json` — uses Cursor's default base image (which already ships Python 3.12 and Node 22) with a single idempotent `install` step.
- `.cursor/install.sh` — provisions the two toolchains the default image lacks (`uv` for the Python engine, `bun` for the TypeScript clients), then installs all locked dependencies. Mirrors the canonical commands in `.github/workflows/ci.yml` and `AGENTS.md`.

## Why

The default image lacks `uv` and `bun`. This bootstrap makes the full dev experience (deterministic engine + AI-KP + TS clients) reproducible for future agents. No `start`/`terminals` are declared: the dev loop is test- and CLI-driven, and `AGENTS.md` explicitly warns against foregrounding the blocking server.

## Validation (this VM)

| Check | Result |
| --- | --- |
| `uv sync --locked --extra anthropic --extra gemini --extra ejs` | Resolved 68 packages; idempotent on re-run |
| `uv run ruff check …` | All checks passed |
| `uv run python scripts/i18n_lint.py` | OK (156 files scanned) |
| `uv run pytest` | 2753 passed, 24 skipped |
| `clients/protocol` — `bun run test` | 91 pass, 0 fail |
| `clients/tui` — `bun test` + `bun run build` | 359 pass, 0 fail; bundle built |
| `python -m app --doctor` | OK: all checks passed |
| `python -m app --cli` (CoC7 + D&D 5e) | Real dice + deterministic check ladder resolved |
| `.cursor/install.sh` from clean env | Completed successfully |

## Validation (fresh Cloud Agent booted from the tested build)

Draft build `bld-20260904-6c84d7d9-...` SUCCEEDED; a fresh agent booted from it passed 6/6 checks:

| Check | Result |
| --- | --- |
| Toolchains on PATH | `uv 0.12.9`, `bun 1.4.1`, `node v22.14.0`, `python3 3.12.3` |
| Python venv + deps baked in | `import openai, pydantic, anthropic, google.genai, quickjs, iroh` → OK |
| Client `node_modules` present | protocol + tui |
| `python -m app --doctor` | OK: all checks passed |
| CLI dice + CoC check | `Roll: 2d6+3 = 11`; `Spot Hidden … -> Hard Success` |
| Offline test slice | `113 passed, 2664 deselected` (dice) |

End-to-end CLI transcript (offline deterministic engine, no LLM key):

```
Roll: 3d6+2 = [4, 4, 1]+2 = 11
Roll: 4d6kh3 = [5, 4, 4] = 13
Check Spot Hidden: target 25 (effective 25), roll 39 -> Failure
Check Stealth: target 20 (effective 20), roll 50 -> Failure
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2994d4e-af24-4b5c-9fbe-3fecbf934fcc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2994d4e-af24-4b5c-9fbe-3fecbf934fcc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

