### PR TITLE
feat(imagegen): add MuAPI URL-output preset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,13 @@ TRPG_TUI__JOIN_TIMEOUT=10
 #
 # It only ever runs for a room whose enabled module ships a presentation kit
 # (`ui/presentation.yaml`), so a table with no such module is never charged for it.
+# Built-in image presets include `openai`, `muapi`, and `supergrok`. The MuAPI preset
+# supplies `https://api.muapi.ai/v1` and `flux-schnell`; only the key is required here.
+# TRPG_IMAGEGEN__PROVIDER=muapi
+# TRPG_IMAGEGEN__API_KEY=...
+# TRPG_IMAGEGEN__MODEL=flux-schnell
+# TRPG_IMAGEGEN__SIZE=1024x1024
+# TRPG_IMAGEGEN__BASE_URL=https://api.muapi.ai/v1
 # TRPG_DIRECTOR__ENABLED=1
 # TRPG_DIRECTOR__PROVIDER=
 # TRPG_DIRECTOR__CHAT_MODEL=

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -137,6 +137,19 @@ Image generation additionally needs all three of these to agree:
 `MAX_IMAGES` is a lifetime cap per room (rooms are long-lived campaigns). Past it the Director keeps
 staging with pack art and already-generated subjects and simply stops spending.
 
+For MuAPI image generation, use the built-in provider preset and set its key:
+
+```dotenv
+TRPG_IMAGEGEN__PROVIDER=muapi
+TRPG_IMAGEGEN__API_KEY=...
+# Optional: these are the MuAPI preset defaults.
+# TRPG_IMAGEGEN__BASE_URL=https://api.muapi.ai/v1
+# TRPG_IMAGEGEN__MODEL=flux-schnell
+```
+
+The preset uses MuAPI's documented URL-returning image-generation response. Reference images fall
+back to prompt-only generation because the public image surface does not define an edit endpoint.
+
 ### Local models
 
 Point `TRPG_LLM__PROVIDER` at `ollama` or `lmstudio` when prompts must not leave your machine. This

--- a/docs/operating.zh.md
+++ b/docs/operating.zh.md
@@ -108,6 +108,18 @@ TRPG_SCRIBE__REASONING_EFFORT=low
 
 `MAX_IMAGES` 是每个房间的终身上限（房间是长期战役，不是单场）。超了之后导演继续用包内美术和已经生成过的素材做舞台，只是不再花钱。
 
+要用 MuAPI 生图，可以直接使用内置的 provider 预设，只填 key：
+
+```dotenv
+TRPG_IMAGEGEN__PROVIDER=muapi
+TRPG_IMAGEGEN__API_KEY=...
+# 可选：下面就是 MuAPI 预设的默认值。
+# TRPG_IMAGEGEN__BASE_URL=https://api.muapi.ai/v1
+# TRPG_IMAGEGEN__MODEL=flux-schnell
+```
+
+这个预设使用 MuAPI 文档中返回 URL 的生图响应。由于公开的生图接口没有定义编辑 endpoint，带参考图时会退回仅使用提示词的生成。
+
 ### 本地模型
 
 提示不能出你这台机器的话，把 `TRPG_LLM__PROVIDER` 指向 `ollama` 或 `lmstudio`。只有这一种配置能让模组正文、守秘人设定和玩家输入都留在你自己掌控的基础设施上——自托管**服务器**本身并不会让模型流量也变成本地的。

--- a/infra/imagegen.py
+++ b/infra/imagegen.py
@@ -22,14 +22,19 @@ if TYPE_CHECKING:
     from infra.runtime_config import CredentialBook
 
 OPENAI_IMAGE_BASE_URL = "https://api.openai.com/v1"
+MUAPI_IMAGE_BASE_URL = "https://api.muapi.ai/v1"
+MUAPI_DEFAULT_IMAGE_MODEL = "flux-schnell"
 IMAGEGEN_OVERRIDE_FIELDS: tuple[str, ...] = ("provider", "base_url", "api_key", "model", "size")
 
 # Provider presets: base_url + default model. ``supergrok`` reuses the SuperGrok
 # subscription token from the LLM credential book (not a separate image key).
 IMAGEGEN_PRESETS: dict[str, dict[str, str]] = {
     "openai": {"base_url": OPENAI_IMAGE_BASE_URL, "model": "gpt-image-1"},
+    "muapi": {"base_url": MUAPI_IMAGE_BASE_URL, "model": MUAPI_DEFAULT_IMAGE_MODEL},
     "supergrok": {"base_url": XAI_API_BASE, "model": XAI_DEFAULT_IMAGE_MODEL},
 }
+
+MAX_IMAGE_BYTES = 64 * 1024 * 1024
 
 TokenProvider = Callable[[], Awaitable[str]]
 
@@ -128,56 +133,104 @@ class OpenAICompatImageGen:
         request_body = {
             "model": self._settings.model,
             "prompt": prompt,
-            "response_format": "b64_json",
         }
-        if (self._settings.provider or "").casefold() == "supergrok":
+        provider = (self._settings.provider or "").casefold()
+        if provider == "supergrok":
             # xAI's Imagine API uses aspect_ratio + 1k/2k resolution rather
             # than OpenAI's pixel-based `size` field.
             request_body.update(_xai_dimensions(requested_size))
         else:
             request_body["size"] = requested_size
+            # MuAPI documents URL results and does not document response_format.
+            # Other OpenAI-compatible providers keep the existing base64 request.
+            if provider == "muapi":
+                request_body["n"] = 1
+            else:
+                request_body["response_format"] = "b64_json"
 
         base = _base_url(self._settings).rstrip("/")
         try:
-            if reference:
-                # A 定妆 reference means image-to-image, which is a DIFFERENT endpoint
-                # and a multipart body on the OpenAI-compatible surface. `response_format`
-                # is not accepted there; edits answer b64 by default.
-                request_body.pop("response_format", None)
-                response = await client.post(
-                    f"{base}/images/edits",
-                    headers={"Authorization": f"Bearer {api_key}"},
-                    data={key: str(value) for key, value in request_body.items()},
-                    files={"image": ("reference.png", reference, reference_mime or "image/png")},
-                )
-            else:
-                response = await client.post(
-                    f"{base}/images/generations",
-                    headers={"Authorization": f"Bearer {api_key}"},
-                    json=request_body,
-                )
-        except httpx.TimeoutException as exc:
-            raise ImageGenError("imagegen_timeout") from exc
-        except httpx.HTTPError as exc:
-            raise ImageGenError("imagegen_http_error") from exc
+            try:
+                if reference and provider != "muapi":
+                    # A 定妆 reference means image-to-image, which is a DIFFERENT endpoint
+                    # and a multipart body on the OpenAI-compatible surface. `response_format`
+                    # is not accepted there; edits answer b64 by default.
+                    response = await client.post(
+                        f"{base}/images/edits",
+                        headers={"Authorization": f"Bearer {api_key}"},
+                        data={
+                            key: str(value)
+                            for key, value in request_body.items()
+                            if key != "response_format"
+                        },
+                        files={"image": ("reference.png", reference, reference_mime or "image/png")},
+                    )
+                else:
+                    response = await client.post(
+                        f"{base}/images/generations",
+                        headers={"Authorization": f"Bearer {api_key}"},
+                        json=request_body,
+                    )
+            except httpx.TimeoutException as exc:
+                raise ImageGenError("imagegen_timeout") from exc
+            except httpx.HTTPError as exc:
+                raise ImageGenError("imagegen_http_error") from exc
+
+            if response.status_code < 200 or response.status_code >= 300:
+                raise ImageGenError("imagegen_http_error", str(response.status_code))
+
+            try:
+                payload = response.json()
+                entry = payload["data"][0]
+                if not isinstance(entry, dict):
+                    raise TypeError
+                if "b64_json" in entry:
+                    data = base64.b64decode(str(entry["b64_json"]), validate=True)
+                elif "url" in entry:
+                    data = await self._download_output(client, entry["url"])
+                else:
+                    raise KeyError("b64_json or url")
+            except (KeyError, IndexError, TypeError, ValueError, binascii.Error) as exc:
+                raise ImageGenError("imagegen_bad_response") from exc
+            if not data:
+                raise ImageGenError("imagegen_bad_response")
+            declared_mime = entry.get("mime_type") if isinstance(entry, dict) else None
+            return data, _detect_image_mime(data, declared_mime)
         finally:
             if close_client:
                 await client.aclose()
 
-        if response.status_code < 200 or response.status_code >= 300:
-            raise ImageGenError("imagegen_http_error", str(response.status_code))
-
+    async def _download_output(self, client: httpx.AsyncClient, value: object) -> bytes:
         try:
-            payload = response.json()
-            entry = payload["data"][0]
-            b64 = entry["b64_json"]
-            data = base64.b64decode(str(b64), validate=True)
-        except (KeyError, IndexError, TypeError, ValueError, binascii.Error) as exc:
+            output_url = httpx.URL(str(value))
+        except (TypeError, ValueError) as exc:
             raise ImageGenError("imagegen_bad_response") from exc
+        if output_url.scheme != "https" or not output_url.host or output_url.username or output_url.password:
+            raise ImageGenError("imagegen_bad_response")
+        try:
+            async with client.stream("GET", output_url, follow_redirects=False) as response:
+                if response.status_code != 200:
+                    raise ImageGenError("imagegen_http_error", str(response.status_code))
+                content_length = response.headers.get("content-length")
+                if content_length and int(content_length) > MAX_IMAGE_BYTES:
+                    raise ImageGenError("imagegen_bad_response")
+                chunks: list[bytes] = []
+                total = 0
+                async for chunk in response.aiter_bytes():
+                    total += len(chunk)
+                    if total > MAX_IMAGE_BYTES:
+                        raise ImageGenError("imagegen_bad_response")
+                    chunks.append(chunk)
+        except ValueError as exc:
+            raise ImageGenError("imagegen_bad_response") from exc
+        except httpx.TimeoutException as exc:
+            raise ImageGenError("imagegen_timeout") from exc
+        except httpx.HTTPError as exc:
+            raise ImageGenError("imagegen_http_error") from exc
+        data = b"".join(chunks)
         if not data:
             raise ImageGenError("imagegen_bad_response")
-        declared_mime = entry.get("mime_type") if isinstance(entry, dict) else None
-        return data, _detect_image_mime(data, declared_mime)
+        return data
 
 
 class FakeImageGen:

--- a/tests/infra/test_imagegen.py
+++ b/tests/infra/test_imagegen.py
@@ -6,7 +6,14 @@ import httpx
 import pytest
 
 from infra.config import ImageGenSettings, Settings
-from infra.imagegen import IMAGEGEN_PRESETS, ImageGenError, OpenAICompatImageGen, build_imagegen
+from infra.imagegen import (
+    IMAGEGEN_PRESETS,
+    MUAPI_DEFAULT_IMAGE_MODEL,
+    MUAPI_IMAGE_BASE_URL,
+    ImageGenError,
+    OpenAICompatImageGen,
+    build_imagegen,
+)
 from infra.oauth_flows import XAI_API_BASE, XAI_DEFAULT_IMAGE_MODEL, SubscriptionToken
 from infra.runtime_config import CredentialBook
 from infra.store import Store
@@ -68,6 +75,61 @@ async def test_openai_compat_imagegen_uses_magic_bytes_before_declared_mime():
 
     assert data == image_bytes
     assert mime == "image/jpeg"
+
+
+async def test_muapi_preset_accepts_https_url_results_without_forwarding_api_key():
+    image_bytes = b"\x89PNG\r\n\x1a\nfixture"
+    seen: list[tuple[str, str | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.headers.get("authorization")))
+        if request.url.path.endswith("/images/generations"):
+            body = json.loads(request.read())
+            assert "response_format" not in body
+            assert body["n"] == 1
+            return httpx.Response(200, json={"data": [{"url": "https://cdn.example/image.png"}]})
+        return httpx.Response(200, content=image_bytes, headers={"content-type": "image/png"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    gen = OpenAICompatImageGen(
+        ImageGenSettings(provider="muapi", api_key="secret", model=MUAPI_DEFAULT_IMAGE_MODEL),
+        client=client,
+    )
+    try:
+        data, mime = await gen.generate("a lantern", size="1024x1024")
+    finally:
+        await client.aclose()
+
+    assert data == image_bytes
+    assert mime == "image/png"
+    assert seen == [("POST", "Bearer secret"), ("GET", None)]
+    assert IMAGEGEN_PRESETS["muapi"] == {
+        "base_url": MUAPI_IMAGE_BASE_URL,
+        "model": MUAPI_DEFAULT_IMAGE_MODEL,
+    }
+
+
+async def test_muapi_prompt_only_fallback_does_not_call_undocumented_edit_endpoint():
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        return httpx.Response(
+            200,
+            json={"data": [{"b64_json": base64.b64encode(b"image").decode("ascii")}]},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    gen = OpenAICompatImageGen(
+        ImageGenSettings(provider="muapi", api_key="secret", model=MUAPI_DEFAULT_IMAGE_MODEL),
+        client=client,
+    )
+    try:
+        await gen.generate("a lantern", reference=b"reference")
+    finally:
+        await client.aclose()
+
+    assert seen_paths == ["/v1/images/generations"]
 
 
 async def test_token_provider_preferred_over_api_key():


### PR DESCRIPTION
## What

Add an optional MuAPI image-generation preset to Loreweaver's existing OpenAI-compatible image
provider.

- The preset supplies MuAPI's documented base URL and `flux-schnell` default model.
- Requests use the documented `model`, `prompt`, `n`, and `size` fields without adding an
  undocumented response-format parameter.
- URL results are downloaded over HTTPS with bounded, redirect-free output handling; the API key is
  not forwarded to the returned image URL.
- Reference-image requests use prompt-only generation because the documented image surface does not
  define an edit endpoint.
- Existing providers and their base64/edit behavior remain unchanged.

## Validation

- `uv run pytest -q` — full suite passed with the declared optional extras.
- `uv run ruff check core infra agent gateway net adapters app.py lw_versioning.py scripts`
- `uv run python scripts/i18n_lint.py`
- `git diff --check`
- No live or billable MuAPI generation request was made.

## References

- [MuAPI OpenAI-compatible documentation](https://muapi.ai/docs/openai-compatible)
- [MuAPI API reference](https://muapi.ai/docs/api-reference)
